### PR TITLE
Improve ticket sorting and admin navigation

### DIFF
--- a/mvp-tickets/templates/base.html
+++ b/mvp-tickets/templates/base.html
@@ -11,6 +11,8 @@
   <script src="https://cdn.tailwindcss.com"></script>
   <!-- HTMX -->
   <script src="https://unpkg.com/htmx.org@2.0.3"></script>
+  <!-- Bootstrap Icons -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css" />
 
   {% block head_extra %}{% endblock %}
 </head>
@@ -23,25 +25,31 @@
           <nav class="hidden md:flex items-center gap-4">
             <a href="{% url 'tickets_home' %}" class="text-sm hover:underline">Tickets</a>
             <a href="{% url 'reports_dashboard' %}" class="text-sm hover:underline">Reportes</a>
-            {% if request.user|has_group:"ADMIN" or request.user.is_superuser %}
-              <a href="{% url 'accounts:users_list' %}" class="text-sm hover:underline">Usuarios</a>
-              <a href="{% url 'categories_list' %}" class="text-sm hover:underline">Categorías</a>
-              <a href="{% url 'priorities_list' %}" class="text-sm hover:underline">Prioridades</a>
-              <a href="{% url 'areas_list' %}" class="text-sm hover:underline">Áreas</a>
-              <a href="{% url 'auto_rules_list' %}" class="text-sm hover:underline">Auto-asignación</a>
-
-            {% endif %}
           </nav>
         {% endif %}
       </div>
 
-      <div class="text-sm">
+      <div class="flex items-center gap-4 text-sm">
         {% if request.user.is_authenticated %}
-          Hola, <span class="font-medium">{{ request.user.username }}</span>
-          · <form action="{% url 'logout' %}" method="post" class="inline">
-              {% csrf_token %}
-              <button type="submit" class="text-blue-600 hover:underline">Salir</button>
-            </form>
+          {% if request.user|has_group:"ADMIN" or request.user.is_superuser %}
+            <details class="relative">
+              <summary class="cursor-pointer list-none">Admin</summary>
+              <div class="absolute right-0 mt-1 bg-white border rounded shadow text-sm">
+                <a href="{% url 'accounts:users_list' %}" class="block px-4 py-2 hover:bg-gray-100">Usuarios</a>
+                <a href="{% url 'categories_list' %}" class="block px-4 py-2 hover:bg-gray-100">Categorías</a>
+                <a href="{% url 'priorities_list' %}" class="block px-4 py-2 hover:bg-gray-100">Prioridades</a>
+                <a href="{% url 'areas_list' %}" class="block px-4 py-2 hover:bg-gray-100">Áreas</a>
+                <a href="{% url 'auto_rules_list' %}" class="block px-4 py-2 hover:bg-gray-100">Auto-asignación</a>
+              </div>
+            </details>
+          {% endif %}
+          <div>
+            Hola, <span class="font-medium">{{ request.user.username }}</span>
+            · <form action="{% url 'logout' %}" method="post" class="inline">
+                {% csrf_token %}
+                <button type="submit" class="text-blue-600 hover:underline">Salir</button>
+              </form>
+          </div>
         {% else %}
           <a href="{% url 'login' %}" class="text-blue-600 hover:underline">Ingresar</a>
         {% endif %}

--- a/mvp-tickets/templates/tickets/detail.html
+++ b/mvp-tickets/templates/tickets/detail.html
@@ -66,18 +66,25 @@
           {% csrf_token %}
 
           {% if is_admin_u %}
-            {# ... (bloque de ADMIN se deja igual) ... #}
+            <label class="block text-sm">Asignar a</label>
+            <select name="to_user_id" class="w-full border rounded px-3 py-2 text-sm">
+              {% for u in tech_users %}
+                <option value="{{ u.id }}" {% if t.assigned_to_id == u.id %}selected{% endif %}>{{ u.username }}</option>
+              {% endfor %}
+            </select>
+            <label class="block text-sm mt-2">Motivo (opcional)</label>
+            <input type="text" name="reason" class="w-full border rounded px-3 py-2 text-sm" placeholder="Reasignación" />
+            <button class="bg-blue-600 text-white px-3 py-1.5 rounded text-sm mt-2">Asignar</button>
 
-          {% elif is_tech_u and not t.assigned_to_id %}
-            {# TECH: solo permitir auto-asignar si NO tiene asignado #}
-            <input type="hidden" name="to_user_id" value="{{ request.user.id }}">
-            <label class="block text-sm">Motivo (opcional)</label>
-            <input type="text" name="reason" class="w-full border rounded px-3 py-2 text-sm" placeholder="Auto-asignación" />
-            <button class="bg-blue-600 text-white px-3 py-1.5 rounded text-sm mt-2">Auto-asignarme</button>
-
-          {% elif is_tech_u and t.assigned_to_id == request.user.id %}
-            {# Si ya está asignado a mí, no muestro botón; solo un aviso #}
-            <div class="text-xs text-gray-500">Este ticket ya está asignado a ti.</div>
+          {% elif is_tech_u %}
+            {% if t.assigned_to_id == request.user.id %}
+              <div class="text-xs text-gray-500">Este ticket ya está asignado a ti.</div>
+            {% else %}
+              <input type="hidden" name="to_user_id" value="{{ request.user.id }}">
+              <label class="block text-sm">Motivo (opcional)</label>
+              <input type="text" name="reason" class="w-full border rounded px-3 py-2 text-sm" placeholder="Auto-asignación" />
+              <button class="bg-blue-600 text-white px-3 py-1.5 rounded text-sm mt-2">Auto-asignarme</button>
+            {% endif %}
           {% endif %}
         </form>
       </div>

--- a/mvp-tickets/templates/tickets/list.html
+++ b/mvp-tickets/templates/tickets/list.html
@@ -41,14 +41,35 @@
   <table class="w-full text-sm">
     <thead class="bg-gray-100">
       <tr>
-        <th class="text-left p-2">Código</th>
-        <th class="text-left p-2">Título</th>
-        <th class="text-left p-2">Estado</th>
-        <th class="text-left p-2">Categoría</th>
-        <th class="text-left p-2">Prioridad</th>
-        <th class="text-left p-2">Asignado</th>
+        <th class="text-left p-2">Código
+          <a href="?sort=code{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-up"></i></a>
+          <a href="?sort=-code{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-down"></i></a>
+        </th>
+        <th class="text-left p-2">Título
+          <a href="?sort=title{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-up"></i></a>
+          <a href="?sort=-title{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-down"></i></a>
+        </th>
+        <th class="text-left p-2">Estado
+          <a href="?sort=status{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-up"></i></a>
+          <a href="?sort=-status{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-down"></i></a>
+        </th>
+        <th class="text-left p-2">Categoría
+          <a href="?sort=category__name{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-up"></i></a>
+          <a href="?sort=-category__name{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-down"></i></a>
+        </th>
+        <th class="text-left p-2">Prioridad
+          <a href="?sort=priority__key{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-up"></i></a>
+          <a href="?sort=-priority__key{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-down"></i></a>
+        </th>
+        <th class="text-left p-2">Asignado
+          <a href="?sort=assigned_to__username{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-up"></i></a>
+          <a href="?sort=-assigned_to__username{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-down"></i></a>
+        </th>
         <th class="text-left p-2">SLA</th>
-        <th class="text-left p-2">Creado</th>
+        <th class="text-left p-2">Creado
+          <a href="?sort=created_at{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-up"></i></a>
+          <a href="?sort=-created_at{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-down"></i></a>
+        </th>
       </tr>
     </thead>
     <tbody>
@@ -111,6 +132,48 @@
   </div>
   {% endif %}
 </div>
+
+{% if other_tickets %}
+<h2 class="text-xl font-semibold mt-8 mb-4">Tickets de otros técnicos</h2>
+<div class="w-full bg-white rounded-xl shadow overflow-hidden">
+  <table class="w-full text-sm">
+    <thead class="bg-gray-100">
+      <tr>
+        <th class="text-left p-2">Código
+          <a href="?sort=code{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-up"></i></a>
+          <a href="?sort=-code{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-down"></i></a>
+        </th>
+        <th class="text-left p-2">Título
+          <a href="?sort=title{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-up"></i></a>
+          <a href="?sort=-title{{ qs_no_sort }}" class="ml-1"><i class="bi bi-arrow-down"></i></a>
+        </th>
+        <th class="text-left p-2">Estado</th>
+        <th class="text-left p-2">Categoría</th>
+        <th class="text-left p-2">Prioridad</th>
+        <th class="text-left p-2">Asignado</th>
+        <th class="text-left p-2">SLA</th>
+        <th class="text-left p-2">Creado</th>
+      </tr>
+    </thead>
+    <tbody>
+      {% for t in other_tickets %}
+      <tr class="border-t hover:bg-gray-50">
+        <td class="p-2">
+          <a class="text-blue-600 hover:underline" href="{% url 'ticket_detail' t.id %}">{{ t.code }}</a>
+        </td>
+        <td class="p-2">{{ t.title }}</td>
+        <td class="p-2">{{ t.status }}</td>
+        <td class="p-2">{{ t.category.name }}</td>
+        <td class="p-2">{{ t.priority.key }}</td>
+        <td class="p-2">{% if t.assigned_to %}{{ t.assigned_to.username }}{% else %}-{% endif %}</td>
+        <td class="p-2">{% if t.is_overdue %}<span class="text-xs px-2 py-0.5 rounded bg-red-100 text-red-700 border border-red-200">SLA vencido</span>{% elif t.is_warning %}<span class="text-xs px-2 py-0.5 rounded bg-yellow-100 text-yellow-700 border border-yellow-200">Por vencer (~{{ t.remaining_hours|floatformat:0 }}h)</span>{% endif %}{% if t.is_critical %} <span class="text-xs px-2 py-0.5 rounded bg-red-600 text-white">CRITICAL</span>{% endif %}</td>
+        <td class="p-2">{{ t.created_at }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+</div>
+{% endif %}
 {% endblock %}
 
 


### PR DESCRIPTION
## Summary
- Add Bootstrap icon support and admin dropdown navigation
- Enable column sorting and show other technicians' tickets
- Allow manual assignment with reassignment support

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b8b6ccce548321b82f71fd4b40dcae