### PR TITLE
Add Excel export for ticket reports

### DIFF
--- a/mvp-tickets/helpdesk/urls.py
+++ b/mvp-tickets/helpdesk/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     path("reports/check-sla/", ticket_views.reports_check_sla, name="reports_check_sla"),
     path("reports/export.csv", ticket_views.reports_export_csv, name="reports_export_csv"),
     path("reports/export.pdf", ticket_views.reports_export_pdf, name="reports_export_pdf"),
+    path("reports/export.xlsx", ticket_views.reports_export_excel, name="reports_export_excel"),
 
 
     # Mantenedor de usuarios (solo ADMIN) → usamos el urls.py de accounts

--- a/mvp-tickets/requirements.txt
+++ b/mvp-tickets/requirements.txt
@@ -7,3 +7,4 @@ djangorestframework
 djangorestframework-simplejwt
 psycopg2-binary
 xhtml2pdf
+openpyxl

--- a/mvp-tickets/templates/reports/dashboard.html
+++ b/mvp-tickets/templates/reports/dashboard.html
@@ -28,6 +28,10 @@
       class="bg-slate-700 text-white px-3 py-1.5 rounded text-sm">
       Exportar PDF
     </a>
+    <a href="{% url 'reports_export_excel' %}?from={{ from }}&to={{ to }}"
+      class="bg-indigo-600 text-white px-3 py-1.5 rounded text-sm">
+      Exportar Excel
+    </a>
   </div>
 </form>
 

--- a/mvp-tickets/tickets/tests.py
+++ b/mvp-tickets/tickets/tests.py
@@ -1,3 +1,43 @@
-from django.test import TestCase
+from io import BytesIO
 
-# Create your tests here.
+from django.contrib.auth.models import User
+from django.test import TestCase
+from django.urls import reverse
+
+from catalog.models import Category, Priority
+from tickets.models import Ticket
+
+
+class ReportsExportExcelTests(TestCase):
+    def setUp(self):
+        self.user = User.objects.create_user(username="u1", password="pass")
+        cat = Category.objects.create(name="Cat")
+        pri = Priority.objects.create(key=Priority.LOW)
+        Ticket.objects.create(
+            code="T1",
+            title="Test",
+            description="d",
+            requester=self.user,
+            category=cat,
+            priority=pri,
+        )
+
+    def test_export_excel(self):
+        self.client.login(username="u1", password="pass")
+        url = reverse("reports_export_excel")
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(
+            resp["Content-Type"],
+            "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        )
+
+        from openpyxl import load_workbook
+
+        wb = load_workbook(filename=BytesIO(resp.content))
+        ws = wb.active
+        headers = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+        self.assertIn("code", headers)
+        first_row = [cell.value for cell in next(ws.iter_rows(min_row=2, max_row=2))]
+        self.assertEqual(first_row[0], "T1")
+


### PR DESCRIPTION
## Summary
- add Excel export endpoint for ticket reports
- link Excel export from reports dashboard
- add regression test for Excel export

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68b8b9038f848321881d6e9ec1d86f42