### PR TITLE
Agregar dashboard y traducción de permisos

### DIFF
--- a/mvp-tickets/accounts/permissions.py
+++ b/mvp-tickets/accounts/permissions.py
@@ -27,4 +27,17 @@ PERMISSION_LABELS = {
     "change_area": "Puede cambiar área",
     "delete_area": "Puede eliminar área",
     "view_area": "Puede ver área",
+    # Permisos de usuarios y roles (auth)
+    "add_user": "Puede agregar usuario",
+    "change_user": "Puede cambiar usuario",
+    "delete_user": "Puede eliminar usuario",
+    "view_user": "Puede ver usuario",
+    "add_group": "Puede agregar rol",
+    "change_group": "Puede cambiar rol",
+    "delete_group": "Puede eliminar rol",
+    "view_group": "Puede ver rol",
+    "add_permission": "Puede agregar permiso",
+    "change_permission": "Puede cambiar permiso",
+    "delete_permission": "Puede eliminar permiso",
+    "view_permission": "Puede ver permiso",
 }

--- a/mvp-tickets/helpdesk/settings.py
+++ b/mvp-tickets/helpdesk/settings.py
@@ -129,5 +129,5 @@ DEFAULT_FROM_EMAIL = "mvp@localhost"
 
 
 LOGIN_URL = "login"
-LOGIN_REDIRECT_URL = "tickets_home"
+LOGIN_REDIRECT_URL = "dashboard"
 LOGOUT_REDIRECT_URL = "login"

--- a/mvp-tickets/helpdesk/urls.py
+++ b/mvp-tickets/helpdesk/urls.py
@@ -14,7 +14,8 @@ urlpatterns = [
     path("logout/", auth_views.LogoutView.as_view(next_page="login"), name="logout"),
 
     # --- UI (server-rendered) ---
-    path("", ticket_views.tickets_home, name="tickets_home"),
+    path("", ticket_views.dashboard, name="dashboard"),
+    path("tickets/", ticket_views.tickets_home, name="tickets_home"),
     path("tickets/new/", ticket_views.ticket_create, name="ticket_create"),
     path("tickets/<int:pk>/", ticket_views.ticket_detail, name="ticket_detail"),
     path("tickets/<int:pk>/print/", ticket_views.ticket_print, name="ticket_print"),

--- a/mvp-tickets/templates/base.html
+++ b/mvp-tickets/templates/base.html
@@ -32,11 +32,12 @@
   <header class="bg-gradient-to-r from-indigo-600 to-blue-500 shadow text-white">
     <div class="max-w-6xl mx-auto px-4 py-3 flex justify-between items-center">
       <div class="flex items-center gap-6">
-        <a href="{% url 'tickets_home' %}" class="font-semibold hover:text-yellow-200 transition-colors">Helpdesk</a>
+        <a href="{% url 'dashboard' %}" class="font-semibold hover:text-yellow-200 transition-colors">Helpdesk</a>
         {% if request.user.is_authenticated %}
           <nav class="hidden md:flex items-center gap-4">
             <a href="{% url 'tickets_home' %}" class="text-sm hover:text-yellow-200 transition-colors">Tickets</a>
             <a href="{% url 'reports_dashboard' %}" class="text-sm hover:text-yellow-200 transition-colors">Reportes</a>
+            <a href="{% url 'dashboard' %}" class="text-sm hover:text-yellow-200 transition-colors">Dashboard</a>
           </nav>
         {% endif %}
       </div>

--- a/mvp-tickets/templates/dashboard.html
+++ b/mvp-tickets/templates/dashboard.html
@@ -1,0 +1,72 @@
+{% extends "base.html" %}
+{% block title %}Dashboard{% endblock %}
+
+{% block content %}
+<h1 class="text-2xl font-bold mb-6">Dashboard</h1>
+<p class="mb-4 text-gray-600">Resumen {{ scope }}.</p>
+
+<div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4 mb-8">
+  <div class="p-4 rounded-lg shadow bg-blue-100">
+    <div class="flex items-center">
+      <i class="bi bi-ticket-perforated text-3xl text-blue-700 mr-3"></i>
+      <div>
+        <div class="text-sm text-blue-700">Abiertos</div>
+        <div class="text-2xl font-semibold">{{ counts.open }}</div>
+      </div>
+    </div>
+  </div>
+  <div class="p-4 rounded-lg shadow bg-yellow-100">
+    <div class="flex items-center">
+      <i class="bi bi-play-circle text-3xl text-yellow-600 mr-3"></i>
+      <div>
+        <div class="text-sm text-yellow-600">En progreso</div>
+        <div class="text-2xl font-semibold">{{ counts.in_progress }}</div>
+      </div>
+    </div>
+  </div>
+  <div class="p-4 rounded-lg shadow bg-green-100">
+    <div class="flex items-center">
+      <i class="bi bi-check-circle text-3xl text-green-600 mr-3"></i>
+      <div>
+        <div class="text-sm text-green-600">Resueltos</div>
+        <div class="text-2xl font-semibold">{{ counts.resolved }}</div>
+      </div>
+    </div>
+  </div>
+  <div class="p-4 rounded-lg shadow bg-gray-200">
+    <div class="flex items-center">
+      <i class="bi bi-archive text-3xl text-gray-700 mr-3"></i>
+      <div>
+        <div class="text-sm text-gray-700">Cerrados</div>
+        <div class="text-2xl font-semibold">{{ counts.closed }}</div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<div class="max-w-md mx-auto">
+  <canvas id="statusChart"></canvas>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+<script>
+  const ctx = document.getElementById('statusChart').getContext('2d');
+  const data = {{ chart_data|safe }};
+  new Chart(ctx, {
+    type: 'pie',
+    data: {
+      labels: data.labels,
+      datasets: [{
+        data: data.data,
+        backgroundColor: ['#bfdbfe', '#fef3c7', '#bbf7d0', '#e5e7eb'],
+        borderWidth: 1
+      }]
+    },
+    options: {
+      plugins: {
+        legend: { position: 'bottom' }
+      }
+    }
+  });
+</script>
+{% endblock %}


### PR DESCRIPTION
## Resumen
- Traducir permisos de usuarios y roles al español
- Agregar dashboard con indicadores y gráfico circular
- Ajustar rutas y navbar para acceder al nuevo dashboard

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b8cc8ee688832186a1917a028bffda