### PR TITLE
Traducción completa de roles al español

### DIFF
--- a/mvp-tickets/accounts/management/commands/init_rbac.py
+++ b/mvp-tickets/accounts/management/commands/init_rbac.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
 from tickets.models import Ticket, TicketComment, TicketAttachment
 from catalog.models import Category, Priority, Area
+from accounts.roles import ROLE_ADMIN, ROLE_TECH, ROLE_REQUESTER
 
 class Command(BaseCommand):
     help = "Inicializa grupos y asigna permisos por defecto"
@@ -17,9 +18,9 @@ class Command(BaseCommand):
         custom_codes = ["assign_ticket", "transition_ticket", "comment_internal", "view_all_tickets"]
         custom = list(Permission.objects.filter(codename__in=custom_codes))
 
-        requester, _ = Group.objects.get_or_create(name="REQUESTER")
-        tech, _ = Group.objects.get_or_create(name="TECH")
-        admin, _ = Group.objects.get_or_create(name="ADMIN")
+        requester, _ = Group.objects.get_or_create(name=ROLE_REQUESTER)
+        tech, _ = Group.objects.get_or_create(name=ROLE_TECH)
+        admin, _ = Group.objects.get_or_create(name=ROLE_ADMIN)
 
         cat_perms = std_perms(Category) + std_perms(Priority) + std_perms(Area)
         t_perms   = std_perms(Ticket) + custom

--- a/mvp-tickets/accounts/roles.py
+++ b/mvp-tickets/accounts/roles.py
@@ -1,0 +1,21 @@
+# accounts/roles.py
+"""Constantes y helpers para roles de usuario."""
+
+ROLE_ADMIN = "ADMINISTRADOR"
+ROLE_TECH = "TECNICO"
+ROLE_REQUESTER = "SOLICITANTE"
+
+
+def is_admin(user):
+    """True si es superusuario o pertenece al grupo ADMINISTRADOR."""
+    return user.is_superuser or user.groups.filter(name=ROLE_ADMIN).exists()
+
+
+def is_tech(user):
+    """True si pertenece al grupo TECNICO."""
+    return user.groups.filter(name=ROLE_TECH).exists()
+
+
+def is_requester(user):
+    """True si pertenece al grupo SOLICITANTE."""
+    return user.groups.filter(name=ROLE_REQUESTER).exists()

--- a/mvp-tickets/accounts/views.py
+++ b/mvp-tickets/accounts/views.py
@@ -8,16 +8,16 @@ from django.contrib.auth import get_user_model
 from django.contrib.auth.models import Group
 
 from .forms import UserCreateForm, UserEditForm, RoleForm
-from tickets.api import is_admin  # mismo helper de roles que ya usas
+from accounts.roles import is_admin, ROLE_ADMIN
 
 User = get_user_model()
 
 
 @login_required
 def users_list(request):
-    """Listado de usuarios (solo ADMIN). Filtros básicos por texto, estado y grupo."""
+    """Listado de usuarios (solo ADMINISTRADOR). Filtros básicos por texto, estado y grupo."""
     if not is_admin(request.user):
-        messages.error(request, "Solo ADMIN puede ver usuarios.")
+        messages.error(request, f"Solo {ROLE_ADMIN} puede ver usuarios.")
         return redirect("tickets_home")
 
     q = (request.GET.get("q") or "").strip()
@@ -50,9 +50,9 @@ def users_list(request):
 
 @login_required
 def user_create(request):
-    """Crear nuevo usuario (solo ADMIN)."""
+    """Crear nuevo usuario (solo ADMINISTRADOR)."""
     if not is_admin(request.user):
-        messages.error(request, "Solo ADMIN puede crear usuarios.")
+        messages.error(request, f"Solo {ROLE_ADMIN} puede crear usuarios.")
         return redirect("tickets_home")
 
     if request.method == "POST":
@@ -75,9 +75,9 @@ def user_create(request):
 
 @login_required
 def user_edit(request, pk):
-    """Editar usuario (solo ADMIN)."""
+    """Editar usuario (solo ADMINISTRADOR)."""
     if not is_admin(request.user):
-        messages.error(request, "Solo ADMIN puede editar usuarios.")
+        messages.error(request, f"Solo {ROLE_ADMIN} puede editar usuarios.")
         return redirect("tickets_home")
 
     user = get_object_or_404(User, pk=pk)
@@ -103,9 +103,9 @@ def user_edit(request, pk):
 
 @login_required
 def user_toggle(request, pk):
-    """Activar/Desactivar usuario (solo ADMIN)."""
+    """Activar/Desactivar usuario (solo ADMINISTRADOR)."""
     if not is_admin(request.user):
-        messages.error(request, "Solo ADMIN puede cambiar estado de usuarios.")
+        messages.error(request, f"Solo {ROLE_ADMIN} puede cambiar estado de usuarios.")
         return redirect("tickets_home")
 
     user = get_object_or_404(User, pk=pk)
@@ -117,9 +117,9 @@ def user_toggle(request, pk):
 
 @login_required
 def roles_list(request):
-    """Listado de roles (solo ADMIN)."""
+    """Listado de roles (solo ADMINISTRADOR)."""
     if not is_admin(request.user):
-        messages.error(request, "Solo ADMIN puede ver roles.")
+        messages.error(request, f"Solo {ROLE_ADMIN} puede ver roles.")
         return redirect("tickets_home")
 
     roles = Group.objects.all().order_by("name")
@@ -128,9 +128,9 @@ def roles_list(request):
 
 @login_required
 def role_create(request):
-    """Crear rol y asignar permisos (solo ADMIN)."""
+    """Crear rol y asignar permisos (solo ADMINISTRADOR)."""
     if not is_admin(request.user):
-        messages.error(request, "Solo ADMIN puede crear roles.")
+        messages.error(request, f"Solo {ROLE_ADMIN} puede crear roles.")
         return redirect("tickets_home")
 
     if request.method == "POST":
@@ -148,9 +148,9 @@ def role_create(request):
 
 @login_required
 def role_edit(request, pk):
-    """Editar rol y sus permisos (solo ADMIN)."""
+    """Editar rol y sus permisos (solo ADMINISTRADOR)."""
     if not is_admin(request.user):
-        messages.error(request, "Solo ADMIN puede editar roles.")
+        messages.error(request, f"Solo {ROLE_ADMIN} puede editar roles.")
         return redirect("tickets_home")
 
     role = get_object_or_404(Group, pk=pk)

--- a/mvp-tickets/catalog/api.py
+++ b/mvp-tickets/catalog/api.py
@@ -1,12 +1,13 @@
 from rest_framework import viewsets, permissions
 from .models import Category, Priority, Area
 from .serializers import CategorySerializer, PrioritySerializer, AreaSerializer
+from accounts.roles import is_admin
 
 class IsAdminOrReadOnly(permissions.BasePermission):
     def has_permission(self, request, view):
         if request.method in ("GET", "HEAD", "OPTIONS"):
             return True
-        return request.user.groups.filter(name="ADMIN").exists()
+        return is_admin(request.user)
 
 class CategoryViewSet(viewsets.ModelViewSet):
     queryset = Category.objects.all()

--- a/mvp-tickets/catalog/views.py
+++ b/mvp-tickets/catalog/views.py
@@ -9,10 +9,7 @@ from .forms import CategoryForm, PriorityForm, AreaForm
 
 
 from django.http import HttpResponseForbidden
-from tickets.api import is_admin  # ya lo tienes
-
-def is_admin(u):
-    return u.is_authenticated and (u.is_superuser or u.groups.filter(name="ADMIN").exists())
+from accounts.roles import is_admin, ROLE_ADMIN
 
 # -------- Categorías --------
 @login_required
@@ -54,14 +51,14 @@ def category_edit(request, pk):
 @login_required
 def priorities_list(request):
     if not is_admin(request.user):
-        return HttpResponseForbidden("Solo ADMIN")
+        return HttpResponseForbidden(f"Solo {ROLE_ADMIN}")
     qs = Priority.objects.all().order_by("name")
     return render(request, "catalog/priorities_list.html", {"rows": qs})
 
 @login_required
 def priority_create(request):
     if not is_admin(request.user):
-        return HttpResponseForbidden("Solo ADMIN")
+        return HttpResponseForbidden(f"Solo {ROLE_ADMIN}")
     if request.method == "POST":
         form = PriorityForm(request.POST)
         if form.is_valid():
@@ -76,7 +73,7 @@ def priority_create(request):
 @login_required
 def priority_edit(request, pk):
     if not is_admin(request.user):
-        return HttpResponseForbidden("Solo ADMIN")
+        return HttpResponseForbidden(f"Solo {ROLE_ADMIN}")
     obj = get_object_or_404(Priority, pk=pk)
     if request.method == "POST":
         form = PriorityForm(request.POST, instance=obj)

--- a/mvp-tickets/helpdesk/urls.py
+++ b/mvp-tickets/helpdesk/urls.py
@@ -39,7 +39,7 @@ urlpatterns = [
     path("reports/export.xlsx", ticket_views.reports_export_excel, name="reports_export_excel"),
 
 
-    # Mantenedor de usuarios (solo ADMIN) → usamos el urls.py de accounts
+    # Mantenedor de usuarios (solo ADMINISTRADOR) → usamos el urls.py de accounts
     path("users/", include(("accounts.urls", "accounts"), namespace="accounts")),
 
     # Catálogo simple
@@ -64,7 +64,7 @@ urlpatterns = [
     path("auto-assign/<int:pk>/toggle/", ticket_views.auto_rule_toggle, name="auto_rule_toggle"),
     path("auto-assign/<int:pk>/delete/", ticket_views.auto_rule_delete, name="auto_rule_delete"),
 
-    # --- Auto-assign rules (ADMIN) ---
+    # --- Reglas de auto-asignación (ADMINISTRADOR) ---
     path("rules/",                ticket_views.auto_rules_list,   name="auto_rules_list"),
     path("rules/new/",            ticket_views.auto_rule_create,  name="auto_rule_create"),
     path("rules/<int:pk>/edit/",  ticket_views.auto_rule_edit,    name="auto_rule_edit"),

--- a/mvp-tickets/reports/api.py
+++ b/mvp-tickets/reports/api.py
@@ -10,14 +10,7 @@ from rest_framework.response import Response
 from rest_framework import permissions
 
 from tickets.models import Ticket
-
-
-def is_admin(u):
-    return u.is_superuser or u.groups.filter(name="ADMIN").exists()
-
-
-def is_tech(u):
-    return u.groups.filter(name="TECH").exists()
+from accounts.roles import is_admin, is_tech
 
 
 def parse_dt(s):
@@ -31,7 +24,7 @@ def base_queryset(request):
     qs = Ticket.objects.select_related("category", "priority", "assigned_to")
     u = request.user
 
-    # filtros por rol (ADMIN ve todo; TECH solo asignados; REQUESTER propios)
+    # filtros por rol (ADMINISTRADOR ve todo; TECNICO solo asignados; SOLICITANTE propios)
     if is_admin(u):
         pass
     elif is_tech(u):

--- a/mvp-tickets/templates/base.html
+++ b/mvp-tickets/templates/base.html
@@ -44,7 +44,7 @@
 
       <div class="flex items-center gap-6 text-sm">
         {% if request.user.is_authenticated %}
-          {% if request.user|has_group:"ADMIN" or request.user.is_superuser %}
+          {% if request.user|has_group:"ADMINISTRADOR" or request.user.is_superuser %}
             <details class="relative">
               <summary class="cursor-pointer list-none bg-white/20 px-2 py-1 rounded hover:bg-white/30 transition-colors">Admin Panel</summary>
               <div class="absolute right-0 mt-1 bg-white border rounded shadow text-sm text-black">

--- a/mvp-tickets/templates/tickets/new.html
+++ b/mvp-tickets/templates/tickets/new.html
@@ -45,7 +45,7 @@
       {% if form.area.errors %}<div class="text-red-600 text-xs">{{ form.area.errors }}</div>{% endif %}
     </div>
 
-    {# Solo aparece si el usuario es ADMIN, porque el form trae el campo #}
+    {# Solo aparece si el usuario es ADMINISTRADOR, porque el form trae el campo #}
     {% if form.assignee %}
     <div>
       <label class="block text-xs">Asignar a (opcional)</label>

--- a/mvp-tickets/tickets/models.py
+++ b/mvp-tickets/tickets/models.py
@@ -135,7 +135,7 @@ class TicketComment(models.Model):
     # Autor del comentario
     author = models.ForeignKey(settings.AUTH_USER_MODEL, on_delete=models.CASCADE)
 
-    # Texto y si es interno (visible solo a TECH/ADMIN)
+    # Texto y si es interno (visible solo a TECNICO/ADMINISTRADOR)
     body = models.TextField()
     is_internal = models.BooleanField(default=False)
 

--- a/mvp-tickets/tickets/templatetags/roles.py
+++ b/mvp-tickets/tickets/templatetags/roles.py
@@ -1,5 +1,6 @@
 # tickets/templatetags/roles.py
 from django import template
+from accounts.roles import ROLE_ADMIN
 
 register = template.Library()
 
@@ -7,15 +8,15 @@ register = template.Library()
 def has_group(user, group_name: str) -> bool:
     """
     Uso en plantillas:
-      {% if request.user|has_group:"ADMIN" %} ... {% endif %}
+      {% if request.user|has_group:"ADMINISTRADOR" %} ... {% endif %}
     Devuelve True si el usuario pertenece al grupo dado.
     Para ADMIN, considera también superuser.
     """
     try:
         if not getattr(user, "is_authenticated", False):
             return False
-        if group_name == "ADMIN":
-            return user.is_superuser or user.groups.filter(name="ADMIN").exists()
+        if group_name == ROLE_ADMIN:
+            return user.is_superuser or user.groups.filter(name=ROLE_ADMIN).exists()
         return user.groups.filter(name=group_name).exists()
     except Exception:
         return False


### PR DESCRIPTION
## Summary
- Centraliza nombres de roles en `accounts/roles.py` con helpers para verificar grupos
- Reemplaza valores en inglés por constantes en vistas, plantillas y comandos de inicialización
- Actualiza filtros de plantillas y mensajes para usar roles en español

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b8d03a3b08832197acab15fc8aad3c