### PR TITLE
Traducir permisos del sistema

### DIFF
--- a/mvp-tickets/accounts/permissions.py
+++ b/mvp-tickets/accounts/permissions.py
@@ -40,4 +40,17 @@ PERMISSION_LABELS = {
     "change_permission": "Puede cambiar permiso",
     "delete_permission": "Puede eliminar permiso",
     "view_permission": "Puede ver permiso",
+    # Permisos del sistema y administración
+    "add_logentry": "Puede agregar registro de admin",
+    "change_logentry": "Puede cambiar registro de admin",
+    "delete_logentry": "Puede eliminar registro de admin",
+    "view_logentry": "Puede ver registro de admin",
+    "add_contenttype": "Puede agregar tipo de contenido",
+    "change_contenttype": "Puede cambiar tipo de contenido",
+    "delete_contenttype": "Puede eliminar tipo de contenido",
+    "view_contenttype": "Puede ver tipo de contenido",
+    "add_session": "Puede agregar sesión",
+    "change_session": "Puede cambiar sesión",
+    "delete_session": "Puede eliminar sesión",
+    "view_session": "Puede ver sesión",
 }


### PR DESCRIPTION
## Summary
- Añadir traducciones en español para permisos del sistema y administración

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b8d872f4f883219f095d11a26523aa