### PR TITLE
Filtrar permisos de roles en español

### DIFF
--- a/mvp-tickets/accounts/forms.py
+++ b/mvp-tickets/accounts/forms.py
@@ -59,7 +59,9 @@ class UserEditForm(forms.ModelForm):
 class RoleForm(forms.ModelForm):
     permissions = forms.ModelMultipleChoiceField(
         label="Permisos",
-        queryset=Permission.objects.all().order_by("content_type__app_label", "codename"),
+        queryset=Permission.objects.filter(
+            codename__in=PERMISSION_LABELS.keys()
+        ).order_by("content_type__app_label", "codename"),
         required=False,
         widget=forms.CheckboxSelectMultiple,
     )

--- a/mvp-tickets/accounts/templatetags/perm_labels.py
+++ b/mvp-tickets/accounts/templatetags/perm_labels.py
@@ -8,6 +8,15 @@ def perm_label(permission):
     """Devuelve el nombre en español del permiso dado."""
     try:
         code = getattr(permission, "codename", "")
-        return PERMISSION_LABELS.get(code, getattr(permission, "name", code))
+        return PERMISSION_LABELS.get(code, "")
     except Exception:
-        return getattr(permission, "name", "")
+        return ""
+
+
+@register.filter
+def perm_known(perms):
+    """Filtra una lista/queryset de permisos dejando solo los conocidos."""
+    try:
+        return [p for p in perms if getattr(p, "codename", "") in PERMISSION_LABELS]
+    except Exception:
+        return []

--- a/mvp-tickets/templates/accounts/roles_list.html
+++ b/mvp-tickets/templates/accounts/roles_list.html
@@ -21,11 +21,15 @@
     <tr class="border-t hover:bg-gray-50">
       <td class="p-2">{{ r.name }}</td>
       <td class="p-2">
-        {% for p in r.permissions.all %}
-          <span class="text-xs px-2 py-0.5 rounded bg-gray-100 border mr-1">{{ p|perm_label }}</span>
-        {% empty %}
-          <span class="text-xs text-gray-500">—</span>
-        {% endfor %}
+        {% with perms=r.permissions.all|perm_known %}
+          {% if perms %}
+            {% for p in perms %}
+              <span class="text-xs px-2 py-0.5 rounded bg-gray-100 border mr-1">{{ p|perm_label }}</span>
+            {% endfor %}
+          {% else %}
+            <span class="text-xs text-gray-500">—</span>
+          {% endif %}
+        {% endwith %}
       </td>
       <td class="p-2">
         <a class="text-blue-600 hover:underline" href="{% url 'accounts:role_edit' r.id %}">Editar</a>


### PR DESCRIPTION
## Summary
- Muestra solo permisos con etiqueta en español en el formulario de roles
- Oculta permisos sin traducción al listar roles
- Añade filtros de plantilla para manejar permisos conocidos

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68b8da646aa48321bad083e56772c7b0