### PR TITLE
Add urgency report type and improve time picker display

### DIFF
--- a/mvp-tickets/reports/api.py
+++ b/mvp-tickets/reports/api.py
@@ -47,6 +47,9 @@ class ReportSummaryView(APIView):
 
     def get(self, request):
         qs = base_queryset(request)
+        report_type = request.query_params.get("type")
+        if report_type == "urgencia":
+            qs = qs.filter(priority__name__icontains="urgencia")
 
         # --- by_status robusto (incluye estados con 0) ---
         status_list = list(qs.values_list("status", flat=True))
@@ -96,6 +99,9 @@ class ReportExportView(APIView):
 
     def get(self, request):
         qs = base_queryset(request)
+        report_type = request.query_params.get("type")
+        if report_type == "urgencia":
+            qs = qs.filter(priority__name__icontains="urgencia")
 
         # --- Config CSV / Excel ---
         # Excel (es-CL/es-ES) suele esperar ; como separador

--- a/mvp-tickets/templates/booking/index.html
+++ b/mvp-tickets/templates/booking/index.html
@@ -12,14 +12,26 @@
     <label>Inicio
       <div class="flex gap-2">
         <input type="date" id="starts_at_date" class="border p-1" aria-describedby="start-help" />
-        <input type="time" id="starts_at_time" class="border p-1" aria-describedby="start-help" />
+        <div class="relative">
+          <input type="time" id="starts_at_time" class="border p-1" aria-describedby="start-help" />
+          <div class="pointer-events-none absolute inset-x-0 -top-3 flex justify-between text-[10px] px-1">
+            <span>hrs</span>
+            <span>min</span>
+          </div>
+        </div>
       </div>
       <small id="start-help" class="block text-gray-600">Seleccione fecha y hora (formato 24h).</small>
     </label>
     <label>Término
       <div class="flex gap-2">
         <input type="date" id="ends_at_date" class="border p-1" aria-describedby="end-help" />
-        <input type="time" id="ends_at_time" class="border p-1" aria-describedby="end-help" />
+        <div class="relative">
+          <input type="time" id="ends_at_time" class="border p-1" aria-describedby="end-help" />
+          <div class="pointer-events-none absolute inset-x-0 -top-3 flex justify-between text-[10px] px-1">
+            <span>hrs</span>
+            <span>min</span>
+          </div>
+        </div>
       </div>
       <small id="end-help" class="block text-gray-600">Debe ser posterior al inicio.</small>
     </label>
@@ -42,14 +54,26 @@
     <label>Desde
       <div class="flex gap-2">
         <input type="date" id="from_date" class="border p-1" aria-describedby="from-help" />
-        <input type="time" id="from_time" class="border p-1" aria-describedby="from-help" />
+        <div class="relative">
+          <input type="time" id="from_time" class="border p-1" aria-describedby="from-help" />
+          <div class="pointer-events-none absolute inset-x-0 -top-3 flex justify-between text-[10px] px-1">
+            <span>hrs</span>
+            <span>min</span>
+          </div>
+        </div>
       </div>
       <small id="from-help" class="block text-gray-600">Fecha y hora de inicio del rango.</small>
     </label>
     <label>Hasta
       <div class="flex gap-2">
         <input type="date" id="to_date" class="border p-1" aria-describedby="to-help" />
-        <input type="time" id="to_time" class="border p-1" aria-describedby="to-help" />
+        <div class="relative">
+          <input type="time" id="to_time" class="border p-1" aria-describedby="to-help" />
+          <div class="pointer-events-none absolute inset-x-0 -top-3 flex justify-between text-[10px] px-1">
+            <span>hrs</span>
+            <span>min</span>
+          </div>
+        </div>
       </div>
       <small id="to-help" class="block text-gray-600">Fecha y hora de término del rango.</small>
     </label>

--- a/mvp-tickets/templates/reports/dashboard.html
+++ b/mvp-tickets/templates/reports/dashboard.html
@@ -24,6 +24,7 @@
       <option value="categoria" {% if report_type == 'categoria' %}selected{% endif %}>Por categoría</option>
       <option value="promedio" {% if report_type == 'promedio' %}selected{% endif %}>Tiempo promedio</option>
       <option value="tecnico" {% if report_type == 'tecnico' %}selected{% endif %}>Por técnico</option>
+      <option value="urgencia" {% if report_type == 'urgencia' %}selected{% endif %}>Urgencia</option>
     </select>
   </div>
   <div>
@@ -42,7 +43,7 @@
       class="bg-slate-700 text-white px-3 py-1.5 rounded text-sm">
       Exportar PDF
     </a>
-    <a href="{% url 'reports_export_excel' %}?from={{ from }}&to={{ to }}&tech={{ tech_selected }}"
+    <a href="{% url 'reports_export_excel' %}?from={{ from }}&to={{ to }}&type={{ report_type }}&tech={{ tech_selected }}"
       class="bg-indigo-600 text-white px-3 py-1.5 rounded text-sm">
       Exportar Excel
     </a>
@@ -116,6 +117,10 @@
 {{ chart_cat_slow|json_script:"chart_cat_slow_data" }}
 
 <script>
+  const COLORS = [
+    "#3b82f6", "#10b981", "#f59e0b", "#ef4444", "#8b5cf6",
+    "#14b8a6", "#f87171", "#6366f1", "#84cc16", "#ec4899"
+  ];
   function parseData(id) {
     const el = document.getElementById(id);
     if (!el) return {labels: [], data: []};
@@ -135,7 +140,10 @@
         labels: dataset.labels,
         datasets: [{
           label: title,
-          data: dataset.data
+          data: dataset.data,
+          backgroundColor: dataset.data.map((_, i) => COLORS[i % COLORS.length]),
+          borderColor: dataset.data.map((_, i) => COLORS[i % COLORS.length]),
+          borderWidth: 1
         }]
       },
       options: {

--- a/mvp-tickets/templates/reports/report_pdf.html
+++ b/mvp-tickets/templates/reports/report_pdf.html
@@ -47,6 +47,20 @@
         {% empty %}<tr><td colspan="2">Sin datos</td></tr>{% endfor %}
       </tbody>
     </table>
+  {% elif type == 'urgencia' %}
+    <h2>Tickets de urgencia</h2>
+    <table>
+      <thead><tr><th>Código</th><th>Título</th><th>Estado</th></tr></thead>
+      <tbody>
+        {% for row in urgent_tickets %}
+          <tr>
+            <td>{{ row.code }}</td>
+            <td>{{ row.title }}</td>
+            <td>{{ row.status }}</td>
+          </tr>
+        {% empty %}<tr><td colspan="3">Sin datos</td></tr>{% endfor %}
+      </tbody>
+    </table>
   {% else %}
     <div class="kpi"><strong>Promedio de resolución (hrs):</strong> {{ avg_hours|default:"—" }}</div>
 

--- a/mvp-tickets/tickets/views.py
+++ b/mvp-tickets/tickets/views.py
@@ -598,6 +598,8 @@ def reports_dashboard(request):
         qs = qs.filter(assigned_to_id=tech_selected)
 
     report_type = request.GET.get("type", "total")
+    if report_type == "urgencia":
+        qs = qs.filter(priority__name__icontains="urgencia")
 
     # Métricas base
     by_status_raw = dict(qs.values_list("status").annotate(c=Count("id")))
@@ -861,6 +863,7 @@ def reports_export_excel(request):
     category = (request.GET.get("category") or "").strip()
     priority = (request.GET.get("priority") or "").strip()
     tech = (request.GET.get("tech") or "").strip()
+    report_type = (request.GET.get("type") or "").strip()
     q = (request.GET.get("q") or "").strip()
 
     if status:
@@ -871,6 +874,8 @@ def reports_export_excel(request):
         qs = qs.filter(priority_id=priority)
     if tech:
         qs = qs.filter(assigned_to_id=tech)
+    if report_type == "urgencia":
+        qs = qs.filter(priority__name__icontains="urgencia")
     if q:
         qs = qs.filter(
             Q(code__icontains=q)
@@ -1004,6 +1009,10 @@ def reports_export_pdf(request):
             .values("assigned_to__username")
             .annotate(count=Count("id"))
             .order_by("-count")
+        )
+    elif report_type == "urgencia":
+        ctx["urgent_tickets"] = list(
+            qs.values("code", "title", "status").order_by("-created_at")
         )
     else:
         by_status_raw = dict(qs.values_list("status").annotate(c=Count("id")))


### PR DESCRIPTION
## Summary
- Show hour/minute labels above time inputs so columns are identified
- Give report charts individual colors
- Support `urgencia` report type for exports and API

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ba028135b483218218c7c1ed338b5e