### PR TITLE
Adjust header branding layout and colors

### DIFF
--- a/mvp-tickets/templates/base.html
+++ b/mvp-tickets/templates/base.html
@@ -30,11 +30,11 @@
 </head>
 <body class="bg-gray-50 text-gray-900">
   <header class="bg-gradient-to-r from-indigo-600 to-blue-500 shadow text-white">
-    <div class="max-w-6xl mx-auto px-4 py-3 flex justify-between items-center">
+    <div class="w-full pl-2 pr-4 py-3 flex justify-between items-center">
       <div class="flex items-center gap-6">
-        <a href="{% url 'dashboard' %}" class="relative font-semibold transition-colors group hover:text-yellow-200">
-          Coya<span class="relative inline-block">h
-            <span class="absolute top-full left-1/2 -translate-x-1/2 flex flex-col items-center text-xs leading-none transition-all duration-300 group-hover:scale-110 group-hover:-translate-y-1 group-hover:text-yellow-200">
+        <a href="{% url 'dashboard' %}" class="relative font-bold text-2xl transition-colors group hover:text-yellow-200">
+          Coya<span class="relative inline-block text-transparent bg-clip-text bg-gradient-to-b from-white via-gray-500 to-black group-hover:text-yellow-200">h
+            <span class="absolute top-full left-1/2 -translate-x-1/2 flex flex-col items-center text-xs leading-none text-gray-800 transition-all duration-300 group-hover:scale-110 group-hover:-translate-y-1 group-hover:text-yellow-200">
               <span>e</span>
               <span>l</span>
               <span>p</span>


### PR DESCRIPTION
## Summary
- Move Coyahue brand closer to left edge and enlarge text
- Give `h` a black-to-white gradient and darken vertical “helpdesk” letters

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68ba058d5bec8321bfb093970d40275b