### PR TITLE
Adjust header layout and logo hover effect

### DIFF
--- a/mvp-tickets/templates/base.html
+++ b/mvp-tickets/templates/base.html
@@ -32,29 +32,22 @@
   <header class="bg-gradient-to-r from-indigo-600 to-blue-500 shadow text-white">
     <div class="w-full pl-2 pr-4 py-3 flex justify-between items-center">
       <div class="flex items-center gap-6">
-        <a href="{% url 'dashboard' %}" class="relative font-bold text-2xl transition-colors group hover:text-orange-300">
-          Coya<span class="relative inline-block text-transparent bg-clip-text bg-gradient-to-b from-white via-gray-500 to-black group-hover:text-orange-300">h
-            <span class="absolute top-full left-1/2 -translate-x-1/2 flex flex-col items-center text-2xl leading-none text-gray-800 transition-all duration-300 group-hover:scale-110 group-hover:-translate-y-1 group-hover:text-orange-300">
-              <span>e</span>
-              <span>l</span>
-              <span>p</span>
-              <span>d</span>
-              <span>e</span>
-              <span>s</span>
-              <span>k</span>
-            </span>
-          </span>ue
+        <a href="{% url 'dashboard' %}" class="relative font-bold text-2xl group">
+          <span class="transition-opacity duration-300 group-hover:opacity-0">Coyahue</span>
+          <span class="absolute inset-0 opacity-0 transition-opacity duration-300 group-hover:opacity-100 text-black">Coyahue Helpdesk</span>
         </a>
+        {% if request.user.is_authenticated %}
+        <nav class="hidden md:flex items-center gap-4">
+          <a href="{% url 'tickets_home' %}" class="text-sm hover:text-orange-300 transition-colors">Tickets</a>
+          <a href="{% url 'reports_dashboard' %}" class="text-sm hover:text-orange-300 transition-colors">Reportes</a>
+          <a href="{% url 'dashboard' %}" class="text-sm hover:text-orange-300 transition-colors">Dashboard</a>
+          <a href="{% url 'booking_ui_home' %}" class="text-sm hover:text-orange-300 transition-colors">Reservas</a>
+        </nav>
+        {% endif %}
       </div>
 
       <div class="flex items-center gap-6 text-sm">
         {% if request.user.is_authenticated %}
-          <nav class="hidden md:flex items-center gap-4 mr-4">
-            <a href="{% url 'tickets_home' %}" class="text-sm hover:text-orange-300 transition-colors">Tickets</a>
-            <a href="{% url 'reports_dashboard' %}" class="text-sm hover:text-orange-300 transition-colors">Reportes</a>
-            <a href="{% url 'dashboard' %}" class="text-sm hover:text-orange-300 transition-colors">Dashboard</a>
-            <a href="{% url 'booking_ui_home' %}" class="text-sm hover:text-orange-300 transition-colors">Reservas</a>
-          </nav>
           {% if request.user|has_group:"ADMINISTRADOR" or request.user.is_superuser %}
             <details class="relative">
               <summary class="cursor-pointer list-none bg-white/20 px-2 py-1 rounded hover:bg-white/30 transition-colors">Admin Panel</summary>


### PR DESCRIPTION
## Summary
- Move navigation links next to the Coyahue logo
- Show 'Coyahue Helpdesk' on logo hover

## Testing
- `python manage.py test`

------
https://chatgpt.com/codex/tasks/task_e_68ba08bb503483219a04473b2e0f03d8