### PR TITLE
Permite que técnicos vean tickets existentes y simplifica UI de comentarios

### DIFF
--- a/mvp-tickets/accounts/management/commands/init_rbac.py
+++ b/mvp-tickets/accounts/management/commands/init_rbac.py
@@ -1,43 +1,118 @@
 # accounts/management/commands/init_rbac.py
+"""Comando utilitario para inicializar los roles base del sistema."""
+
 from django.core.management.base import BaseCommand
 from django.contrib.auth.models import Group, Permission
 from django.contrib.contenttypes.models import ContentType
+
 from tickets.models import Ticket, TicketComment, TicketAttachment
 from catalog.models import Category, Priority, Area
 from accounts.roles import ROLE_ADMIN, ROLE_TECH, ROLE_REQUESTER
 
+
 class Command(BaseCommand):
-    help = "Inicializa grupos y asigna permisos por defecto"
+    """Crea (o actualiza) los grupos principales con los permisos esperados."""
+
+    help = (
+        "Inicializa grupos y asigna permisos por defecto para solicitantes, "
+        "técnicos y administradores."
+    )
 
     def handle(self, *args, **kwargs):
+        """Entrypoint del comando ``init_rbac``."""
+
         def std_perms(model):
-            ct = ContentType.objects.get_for_model(model)
-            codes = [f"{c}_{model._meta.model_name}" for c in ("add","change","view","delete")]
-            return list(Permission.objects.filter(content_type=ct, codename__in=codes))
+            """
+            Devuelve los permisos CRUD estándar (add/change/view/delete) para un modelo.
 
-        custom_codes = ["assign_ticket", "transition_ticket", "comment_internal", "view_all_tickets"]
-        custom = list(Permission.objects.filter(codename__in=custom_codes))
+            Mantener esta lógica centralizada evita olvidarnos de registrar alguno
+            al incorporar nuevos catálogos.
+            """
 
-        requester, _ = Group.objects.get_or_create(name=ROLE_REQUESTER)
-        tech, _ = Group.objects.get_or_create(name=ROLE_TECH)
-        admin, _ = Group.objects.get_or_create(name=ROLE_ADMIN)
+            content_type = ContentType.objects.get_for_model(model)
+            codes = [f"{action}_{model._meta.model_name}" for action in ("add", "change", "view", "delete")]
+            return list(
+                Permission.objects.filter(content_type=content_type, codename__in=codes)
+            )
 
-        cat_perms = std_perms(Category) + std_perms(Priority) + std_perms(Area)
-        t_perms   = std_perms(Ticket) + custom
-        tc_perms  = std_perms(TicketComment)
-        ta_perms  = std_perms(TicketAttachment)
+        # Permisos personalizados definidos en tickets/models.py (Meta.permissions)
+        custom_codes = [
+            "assign_ticket",
+            "transition_ticket",
+            "comment_internal",
+            "view_all_tickets",
+        ]
+        custom_perms = list(Permission.objects.filter(codename__in=custom_codes))
 
-        requester.permissions.set([
-            *[p for p in t_perms if p.codename in ("add_ticket","view_ticket")],
-            *[p for p in tc_perms if p.codename.startswith(("add_","view_"))],
-            *[p for p in ta_perms if p.codename.startswith(("add_","view_"))],
-        ])
+        # Aseguramos que existan los tres grupos principales
+        requester_group, _ = Group.objects.get_or_create(name=ROLE_REQUESTER)
+        tech_group, _ = Group.objects.get_or_create(name=ROLE_TECH)
+        admin_group, _ = Group.objects.get_or_create(name=ROLE_ADMIN)
 
-        tech.permissions.set([
-            *[p for p in t_perms if p.codename in ("view_ticket","change_ticket","transition_ticket")],
-            *[p for p in tc_perms if p.codename.startswith(("add_","view_","change_"))],
-            *[p for p in ta_perms if p.codename.startswith(("add_","view_"))],
-        ])
+        # Catálogos: categorías, prioridades y áreas
+        catalog_perms = std_perms(Category) + std_perms(Priority) + std_perms(Area)
 
-        admin.permissions.set(cat_perms + t_perms + tc_perms + ta_perms)
+        # Tickets y entidades relacionadas
+        ticket_perms = std_perms(Ticket) + custom_perms
+        comment_perms = std_perms(TicketComment)
+        attachment_perms = std_perms(TicketAttachment)
+
+        # --- Permisos por rol ---
+        requester_group.permissions.set(
+            [
+                # Puede crear y consultar sus propios tickets
+                *[
+                    perm
+                    for perm in ticket_perms
+                    if perm.codename in ("add_ticket", "view_ticket")
+                ],
+                # Puede agregar y ver comentarios
+                *[
+                    perm
+                    for perm in comment_perms
+                    if perm.codename.startswith(("add_", "view_"))
+                ],
+                # Puede adjuntar evidencia y consultarla
+                *[
+                    perm
+                    for perm in attachment_perms
+                    if perm.codename.startswith(("add_", "view_"))
+                ],
+            ]
+        )
+
+        tech_group.permissions.set(
+            [
+                # Puede ver todos los tickets, actualizarlos y moverlos de estado
+                *[
+                    perm
+                    for perm in ticket_perms
+                    if perm.codename
+                    in (
+                        "view_ticket",
+                        "change_ticket",
+                        "transition_ticket",
+                        "view_all_tickets",
+                    )
+                ],
+                # Gestionar comentarios (crear, ver y editar los suyos)
+                *[
+                    perm
+                    for perm in comment_perms
+                    if perm.codename.startswith(("add_", "view_", "change_"))
+                ],
+                # Adjuntar o revisar archivos vinculados al ticket
+                *[
+                    perm
+                    for perm in attachment_perms
+                    if perm.codename.startswith(("add_", "view_"))
+                ],
+            ]
+        )
+
+        # El rol administrador recibe el set completo de permisos
+        admin_group.permissions.set(
+            catalog_perms + ticket_perms + comment_perms + attachment_perms
+        )
+
         self.stdout.write(self.style.SUCCESS("RBAC inicializado"))

--- a/mvp-tickets/accounts/migrations/0001_update_tech_permissions.py
+++ b/mvp-tickets/accounts/migrations/0001_update_tech_permissions.py
@@ -1,0 +1,50 @@
+"""Asegura que el rol de técnico pueda ver todos los tickets existentes."""
+
+from django.db import migrations
+
+
+def grant_view_all(apps, schema_editor):
+    """Agrega el permiso ``view_all_tickets`` al grupo de técnicos."""
+
+    Group = apps.get_model("auth", "Group")
+    Permission = apps.get_model("auth", "Permission")
+
+    try:
+        tech_group = Group.objects.get(name="TECNICO")
+    except Group.DoesNotExist:
+        return
+
+    try:
+        view_all = Permission.objects.get(codename="view_all_tickets")
+    except Permission.DoesNotExist:
+        return
+
+    tech_group.permissions.add(view_all)
+
+
+def revoke_view_all(apps, schema_editor):
+    """Quita el permiso en caso de reversión manual."""
+
+    Group = apps.get_model("auth", "Group")
+    Permission = apps.get_model("auth", "Permission")
+
+    try:
+        tech_group = Group.objects.get(name="TECNICO")
+        view_all = Permission.objects.get(codename="view_all_tickets")
+    except (Group.DoesNotExist, Permission.DoesNotExist):
+        return
+
+    tech_group.permissions.remove(view_all)
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        ("auth", "0012_alter_user_first_name_max_length"),
+    ]
+
+    operations = [
+        migrations.RunPython(grant_view_all, revoke_view_all),
+    ]

--- a/mvp-tickets/templates/tickets/detail.html
+++ b/mvp-tickets/templates/tickets/detail.html
@@ -131,9 +131,6 @@
 
   <div class="md:col-span-2 grid grid-cols-1 lg:grid-cols-2 gap-4">
     <div class="bg-white rounded-xl shadow p-4 space-y-4">
-      <div class="flex items-center justify-between">
-        <div class="font-medium">Comentarios</div>
-      </div>
       <div id="discussion"
            hx-get="{% url 'discussion_partial' t.id %}"
            hx-trigger="load, revealed"

--- a/mvp-tickets/templates/tickets/partials/discussion.html
+++ b/mvp-tickets/templates/tickets/partials/discussion.html
@@ -23,7 +23,6 @@
   </section>
 
   <section class="pt-2 border-t">
-    <h3 class="font-medium mb-2">Adjuntos</h3>
     <ul class="space-y-2">
       {% for a in attachments %}
         <li class="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2 border rounded-lg p-3 bg-white">


### PR DESCRIPTION
## Summary
- amplía el comando `init_rbac` con comentarios claros y añade el permiso `view_all_tickets` a los técnicos
- agrega una migración que asegura que el grupo TECNICO existente reciba el permiso para ver todos los tickets
- limpia la interfaz de detalle del ticket eliminando los encabezados de “Comentarios” y “Adjuntos” para dejar solo “Nuevo comentario”

## Testing
- python manage.py test

------
https://chatgpt.com/codex/tasks/task_e_68d1b97fae1c8321bf9ee66bee34e48d