### PR TITLE
Load timezone template tags on dashboard

### DIFF
--- a/mvp-tickets/templates/dashboard.html
+++ b/mvp-tickets/templates/dashboard.html
@@ -1,4 +1,5 @@
 {% extends "base.html" %}
+{% load tz %}
 {% block title %}Dashboard{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
## Summary
- load the tz template tag library on the dashboard template to enable timezone filters

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d1c893289c8321b6f8f1f801bc92ef