### PR TITLE
Mejoras en historial y logs en español

### DIFF
--- a/mvp-tickets/templates/logs/list.html
+++ b/mvp-tickets/templates/logs/list.html
@@ -4,10 +4,6 @@
 <h1 class="text-xl font-bold mb-4">Logs</h1>
 <form method="get" class="mb-4 grid grid-cols-2 md:grid-cols-3 gap-2 text-sm">
   <input type="text" name="actor" value="{{ filters.actor }}" placeholder="Actor" class="border p-1" />
-  <select name="model" class="border p-1">
-    <option value="">Modelo</option>
-    <option value="ticket" {% if filters.model == 'ticket' %}selected{% endif %}>Ticket</option>
-  </select>
   <input type="text" name="action" value="{{ filters.action }}" placeholder="Acción" class="border p-1" />
   <input type="text" name="resource" value="{{ filters.resource }}" placeholder="Recurso" class="border p-1" />
   <label class="flex flex-col">
@@ -19,6 +15,9 @@
     <input type="date" name="to" value="{{ filters.to }}" class="border p-1" />
   </label>
   <input type="hidden" name="obj_id" value="{{ filters.obj_id }}" />
+  {% if filters.model %}
+  <input type="hidden" name="model" value="{{ filters.model }}" />
+  {% endif %}
   <button class="btn bg-blue-500 text-white px-2 py-1 col-span-2 md:col-span-3">Filtrar</button>
 </form>
 <table class="w-full text-sm bg-white shadow rounded">
@@ -26,21 +25,27 @@
     <tr class="border-b">
       <th class="p-2 text-left">Fecha</th>
       <th class="p-2 text-left">Actor</th>
-      <th class="p-2 text-left">Modelo</th>
+      <th class="p-2 text-left">Tipo</th>
       <th class="p-2 text-left">ID</th>
       <th class="p-2 text-left">Acción</th>
       <th class="p-2 text-left">Mensaje</th>
     </tr>
   </thead>
   <tbody>
-    {% for log in logs %}
+    {% for row in rows %}
     <tr class="border-b">
-      <td class="p-2">{{ log.created_at }}</td>
-      <td class="p-2">{{ log.actor }}</td>
-      <td class="p-2">{{ log.model }}</td>
-      <td class="p-2">{{ log.obj_id }}</td>
-      <td class="p-2">{{ log.action }}</td>
-      <td class="p-2">{{ log.message }}</td>
+      <td class="p-2">{{ row.created_at }}</td>
+      <td class="p-2">{{ row.actor }}</td>
+      <td class="p-2">{{ row.model }}</td>
+      <td class="p-2">
+        {% if row.url %}
+          <a href="{{ row.url }}" class="text-blue-600 hover:underline">{{ row.obj_id }}</a>
+        {% else %}
+          {{ row.obj_id }}
+        {% endif %}
+      </td>
+      <td class="p-2">{{ row.action }}</td>
+      <td class="p-2">{{ row.message }}</td>
     </tr>
     {% empty %}
     <tr><td colspan="6" class="p-2 text-center text-gray-500">Sin registros</td></tr>

--- a/mvp-tickets/templates/tickets/partials/audit.html
+++ b/mvp-tickets/templates/tickets/partials/audit.html
@@ -1,17 +1,28 @@
 <div class="divide-y">
-  {% for log in logs %}
-    <div class="py-2 text-sm">
-      <div class="flex items-center gap-2">
-        <span class="px-2 py-0.5 rounded border bg-gray-50">{{ log.action }}</span>
+  {% for entry in entries %}
+    <div class="py-2 text-sm space-y-1">
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="px-2 py-0.5 rounded border bg-gray-50">{{ entry.action_label }}</span>
         <span class="text-gray-600">por</span>
-        <span class="font-medium">{{ log.actor__username|default:"(sistema)" }}</span>
-        <span class="text-gray-500 text-xs">· {{ log.created_at }}</span>
+        <span class="font-medium">{{ entry.actor|default:"(sistema)" }}</span>
+        <span class="text-gray-500 text-xs">· {{ entry.created_at }}</span>
       </div>
-      {% if log.meta %}
-        <div class="mt-1 text-xs text-gray-700">
-          {% for k,v in log.meta.items %}
-            <span class="inline-block mr-2"><span class="text-gray-500">{{ k }}:</span> {{ v }}</span>
+      {% if entry.description %}
+        <div class="text-gray-700">{{ entry.description }}</div>
+      {% endif %}
+      {% if entry.notes %}
+        <ul class="text-xs text-gray-600 space-y-0.5">
+          {% for note in entry.notes %}
+            <li>• {{ note }}</li>
           {% endfor %}
+        </ul>
+      {% endif %}
+      {% if entry.comment %}
+        <div class="text-xs bg-gray-50 border rounded px-3 py-2 text-gray-700">
+          {{ entry.comment|linebreaksbr }}
+          {% if entry.comment_is_internal %}
+            <span class="block text-[10px] uppercase text-amber-600 mt-1">Comentario interno</span>
+          {% endif %}
         </div>
       {% endif %}
     </div>

--- a/mvp-tickets/tickets/services.py
+++ b/mvp-tickets/tickets/services.py
@@ -149,7 +149,13 @@ def apply_auto_assign(ticket: Ticket, actor=None) -> bool:
     )
     AuditLog.objects.create(
         ticket=ticket, actor=actor, action="ASSIGN",
-        meta={"from": prev.id if prev else None, "to": rule.tech_id, "reason": "auto-assign"},
+        meta={
+            "from": prev.id if prev else None,
+            "from_username": getattr(prev, "username", None) if prev else None,
+            "to": rule.tech_id,
+            "to_username": getattr(rule.tech, "username", None),
+            "reason": "auto-assign",
+        },
     )
     return True
 


### PR DESCRIPTION
## Summary
- mejorar los metadatos de auditoría al registrar asignaciones, cambios de estado y comentarios para conservar nombres, etiquetas en español y detalles útiles
- mostrar el historial de cada ticket con mensajes amigables en español e indicadores para comentarios, adjuntos y eventos SLA
- simplificar la vista de logs globales eliminando el filtro de modelo y mostrando enlaces directos al ticket con acciones traducidas

## Testing
- `python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_68d1cb29778883218d21208a79299945