### PR TITLE
Improve header layout and dashboard chart sizing

### DIFF
--- a/mvp-tickets/templates/base.html
+++ b/mvp-tickets/templates/base.html
@@ -30,21 +30,29 @@
 </head>
 <body class="bg-gray-50 text-gray-900">
   <header class="bg-gradient-to-r from-indigo-600 to-blue-500 shadow text-white">
-    <div class="w-full pl-2 pr-4 py-3 flex justify-between items-center">
-      <div class="flex items-center gap-6">
-        <a href="{% url 'dashboard' %}" class="relative font-bold text-2xl group flex items-center">
-          <span>Coyahue</span>
-          <span class="inline-block overflow-hidden max-w-0 transition-all duration-300 group-hover:max-w-[120px] group-hover:ml-1">
-            <span class="text-white transition-colors duration-300 group-hover:text-black">h</span><span class="text-black">elpdesk</span>
-          </span>
+    <div class="w-full pl-4 pr-6 py-3 flex justify-between items-center">
+      <div class="flex items-center gap-8">
+        <a href="{% url 'dashboard' %}" class="font-bold text-2xl flex items-center gap-1 tracking-tight">
+          <span class="text-white">Coyahue</span>
+          <span class="text-black">Helpdesk</span>
         </a>
         {% if request.user.is_authenticated %}
-        <nav class="hidden md:flex items-center gap-4 ml-32">
-          <a href="{% url 'tickets_home' %}" class="text-sm hover:text-orange-300 transition-colors">Tickets</a>
-          <a href="{% url 'reports_dashboard' %}" class="text-sm hover:text-orange-300 transition-colors">Reportes</a>
-          <a href="{% url 'dashboard' %}" class="text-sm hover:text-orange-300 transition-colors">Dashboard</a>
-          <a href="{% url 'faq_list' %}" class="text-sm hover:text-orange-300 transition-colors">Preguntas frecuentes</a>
+        {% with current_path=request.path %}
+        <nav class="hidden md:flex items-center gap-3 ml-24 text-sm">
+          <a href="{% url 'tickets_home' %}"
+             class="px-3 py-2 rounded-md transition-colors {% if current_path|slice:':8' == '/tickets' %}bg-white/25 text-white font-semibold shadow-sm{% else %}hover:text-orange-300{% endif %}"
+             aria-current="{% if current_path|slice:':8' == '/tickets' %}page{% endif %}">Tickets</a>
+          <a href="{% url 'reports_dashboard' %}"
+             class="px-3 py-2 rounded-md transition-colors {% if current_path|slice:':8' == '/reports' %}bg-white/25 text-white font-semibold shadow-sm{% else %}hover:text-orange-300{% endif %}"
+             aria-current="{% if current_path|slice:':8' == '/reports' %}page{% endif %}">Reportes</a>
+          <a href="{% url 'dashboard' %}"
+             class="px-3 py-2 rounded-md transition-colors {% if current_path == '/' %}bg-white/25 text-white font-semibold shadow-sm{% else %}hover:text-orange-300{% endif %}"
+             aria-current="{% if current_path == '/' %}page{% endif %}">Dashboard</a>
+          <a href="{% url 'faq_list' %}"
+             class="px-3 py-2 rounded-md transition-colors {% if current_path|slice:':5' == '/faq/' %}bg-white/25 text-white font-semibold shadow-sm{% else %}hover:text-orange-300{% endif %}"
+             aria-current="{% if current_path|slice:':5' == '/faq/' %}page{% endif %}">Preguntas frecuentes</a>
         </nav>
+        {% endwith %}
         {% endif %}
       </div>
 
@@ -79,14 +87,16 @@
             </form>
           </div>
         {% else %}
+          {% if request.resolver_match.url_name != 'login' %}
           <a href="{% url 'login' %}" class="hover:text-orange-300 transition-colors">Ingresar</a>
+          {% endif %}
         {% endif %}
       </div>
     </div>
   </header>
 
 
-  <main class="max-w-6xl mx-auto p-4">
+  <main class="w-full max-w-screen-2xl mx-auto px-6 py-4">
     {# --- Mensajes flash --- #}
     {% if messages %}
       <div class="space-y-2 mb-4">

--- a/mvp-tickets/templates/dashboard.html
+++ b/mvp-tickets/templates/dashboard.html
@@ -84,7 +84,7 @@
           <h2 class="text-2xl font-semibold text-slate-900">Distribución actual</h2>
           <p class="text-sm text-slate-600">Una visión clara del estado de los tickets al momento.</p>
         </div>
-        <div class="mx-auto mt-4 h-80 w-full max-w-md">
+        <div class="mx-auto mt-4 h-96 w-full max-w-2xl">
           <canvas id="statusChart" aria-label="Gráfico circular de estado de tickets"></canvas>
         </div>
         <div id="statusFilters" class="mt-6 flex flex-wrap gap-3">


### PR DESCRIPTION
## Summary
- show the Coyahue Helpdesk branding permanently without the previous hover animation
- highlight the active top navigation item and hide the login link when already on the login view
- widen the main content container and enlarge the dashboard pie chart to use the available space

## Testing
- python manage.py check *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dda678a10c8321b650447b48e2d46b