### PR TITLE
Restore classic menu layout and ticket styling

### DIFF
--- a/mvp-tickets/templates/base.html
+++ b/mvp-tickets/templates/base.html
@@ -28,21 +28,6 @@
     .btn:active {
       transform: scale(0.98);
     }
-    .brand-title {
-      letter-spacing: -0.02em;
-    }
-    .brand-pill {
-      border-radius: 9999px;
-      padding: 0.15rem 0.75rem;
-      background: rgba(255, 255, 255, 0.15);
-      font-size: 0.75rem;
-      text-transform: uppercase;
-      font-weight: 700;
-      letter-spacing: 0.35em;
-      display: inline-flex;
-      align-items: center;
-      gap: 0.35rem;
-    }
     .nav-admin summary::-webkit-details-marker {
       display: none;
     }
@@ -95,39 +80,28 @@
   {% block head_extra %}{% endblock %}
 </head>
 <body class="bg-gray-50 text-gray-900">
-  <header class="bg-gradient-to-r from-indigo-700 via-blue-600 to-sky-500 text-white shadow-lg shadow-indigo-900/20">
-    <div class="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4">
-      <div class="flex items-center gap-10">
-        <a href="{% url 'dashboard' %}" class="group flex items-center gap-3 text-2xl font-semibold leading-none brand-title">
-          <span class="brand-pill">
-            <i class="bi bi-bezier"></i>
-            Coyahue
-          </span>
-          <span class="inline-flex items-center gap-1 rounded-full bg-white/20 px-3 py-1 text-sm font-semibold uppercase tracking-[0.35em] text-white/90">Helpdesk</span>
+  <header class="bg-gradient-to-r from-indigo-600 to-blue-500 shadow text-white">
+    <div class="w-full pl-4 pr-6 py-3 flex justify-between items-center">
+      <div class="flex items-center gap-8">
+        <a href="{% url 'dashboard' %}" class="font-bold text-2xl flex items-center gap-1 tracking-tight">
+          <span class="text-white">Coyahue</span>
+          <span class="text-black">Helpdesk</span>
         </a>
         {% if request.user.is_authenticated %}
         {% with current_path=request.path %}
-        <nav class="hidden md:flex items-center gap-2 text-sm">
+        <nav class="hidden md:flex items-center gap-3 ml-24 text-sm">
           <a href="{% url 'tickets_home' %}"
-             class="inline-flex items-center gap-2 rounded-full px-4 py-2 font-medium transition {% if current_path|slice:':8' == '/tickets' %}bg-white/20 text-white shadow{% else %}text-white/80 hover:bg-white/15 hover:text-white{% endif %}"
-             aria-current="{% if current_path|slice:':8' == '/tickets' %}page{% endif %}">
-            <i class="bi bi-ticket"></i> Tickets
-          </a>
+             class="px-3 py-2 rounded-md transition-colors {% if current_path|slice:':8' == '/tickets' %}bg-white/25 text-white font-semibold shadow-sm{% else %}hover:text-orange-300{% endif %}"
+             aria-current="{% if current_path|slice:':8' == '/tickets' %}page{% endif %}">Tickets</a>
           <a href="{% url 'reports_dashboard' %}"
-             class="inline-flex items-center gap-2 rounded-full px-4 py-2 font-medium transition {% if current_path|slice:':8' == '/reports' %}bg-white/20 text-white shadow{% else %}text-white/80 hover:bg-white/15 hover:text-white{% endif %}"
-             aria-current="{% if current_path|slice:':8' == '/reports' %}page{% endif %}">
-            <i class="bi bi-clipboard-data"></i> Reportes
-          </a>
+             class="px-3 py-2 rounded-md transition-colors {% if current_path|slice:':8' == '/reports' %}bg-white/25 text-white font-semibold shadow-sm{% else %}hover:text-orange-300{% endif %}"
+             aria-current="{% if current_path|slice:':8' == '/reports' %}page{% endif %}">Reportes</a>
           <a href="{% url 'dashboard' %}"
-             class="inline-flex items-center gap-2 rounded-full px-4 py-2 font-medium transition {% if current_path == '/' %}bg-white/20 text-white shadow{% else %}text-white/80 hover:bg-white/15 hover:text-white{% endif %}"
-             aria-current="{% if current_path == '/' %}page{% endif %}">
-            <i class="bi bi-grid-1x2"></i> Dashboard
-          </a>
+             class="px-3 py-2 rounded-md transition-colors {% if current_path == '/' %}bg-white/25 text-white font-semibold shadow-sm{% else %}hover:text-orange-300{% endif %}"
+             aria-current="{% if current_path == '/' %}page{% endif %}">Dashboard</a>
           <a href="{% url 'faq_list' %}"
-             class="inline-flex items-center gap-2 rounded-full px-4 py-2 font-medium transition {% if current_path|slice:':5' == '/faq/' %}bg-white/20 text-white shadow{% else %}text-white/80 hover:bg-white/15 hover:text-white{% endif %}"
-             aria-current="{% if current_path|slice:':5' == '/faq/' %}page{% endif %}">
-            <i class="bi bi-question-circle"></i> Preguntas frecuentes
-          </a>
+             class="px-3 py-2 rounded-md transition-colors {% if current_path|slice:':5' == '/faq/' %}bg-white/25 text-white font-semibold shadow-sm{% else %}hover:text-orange-300{% endif %}"
+             aria-current="{% if current_path|slice:':5' == '/faq/' %}page{% endif %}">Preguntas frecuentes</a>
         </nav>
         {% endwith %}
         {% endif %}
@@ -176,7 +150,7 @@
   </header>
 
 
-  <main class="mx-auto w-full max-w-6xl px-4 py-6 sm:px-6 lg:px-8">
+  <main class="w-full px-6 py-6">
     {# --- Mensajes flash --- #}
     {% if messages %}
       <div class="space-y-2 mb-4">

--- a/mvp-tickets/templates/tickets/list.html
+++ b/mvp-tickets/templates/tickets/list.html
@@ -2,13 +2,17 @@
 {% block title %}Mis tickets{% endblock %}
 
 {% block content %}
+{#
+  Vista principal de tickets.
+  Se reorganiza en secciones para entregar una experiencia más humana y acorde al resto del sitio.
+#}
 <section class="space-y-8">
-  <article class="relative overflow-hidden rounded-3xl border border-blue-100 bg-gradient-to-br from-indigo-500 via-blue-500 to-sky-400 p-8 text-white shadow">
+  <article class="relative overflow-hidden rounded-3xl border border-indigo-100 bg-gradient-to-br from-indigo-600 via-indigo-500 to-sky-500 p-8 text-white shadow">
     <div class="relative z-10 flex flex-col gap-4 md:flex-row md:items-end md:justify-between">
       <div class="max-w-2xl space-y-2">
-        <p class="inline-flex items-center gap-2 rounded-full bg-white/15 px-3 py-1 text-xs font-semibold uppercase tracking-[0.4em]">Tickets</p>
+        <p class="inline-flex items-center gap-2 rounded-full bg-white/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.4em]">Tickets</p>
         <h1 class="text-3xl font-bold tracking-tight">Tu bandeja de solicitudes</h1>
-        <p class="text-sm text-blue-100 md:text-base">
+        <p class="text-sm text-indigo-100 md:text-base">
           Revisa, prioriza y gestiona cada caso sin enredos. Acá tienes una vista clara de lo que está pasando en tiempo real.
         </p>
       </div>
@@ -17,7 +21,7 @@
           <i class="bi bi-plus-circle"></i>
           Levantar ticket
         </a>
-        <span class="text-xs text-blue-100">¿Se cayó algo? Levanta un caso y lo revisamos de inmediato.</span>
+        <span class="text-xs text-indigo-100">¿Se cayó algo? Levanta un caso y lo vemos al tiro.</span>
       </div>
     </div>
     <div class="pointer-events-none absolute -right-20 -top-20 h-64 w-64 rounded-full bg-white/10 blur-3xl"></div>
@@ -29,7 +33,7 @@
     <article class="flex flex-col gap-2 rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
       <div class="flex items-center justify-between">
         <span class="text-sm font-semibold text-slate-600 uppercase tracking-wider">Asignados a ti</span>
-        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-blue-50 text-blue-500"><i class="bi bi-person-workspace"></i></span>
+        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-indigo-100 text-indigo-600"><i class="bi bi-person-workspace"></i></span>
       </div>
       <p class="text-4xl font-semibold text-slate-900">{{ tech_counters.assigned }}</p>
       <p class="text-xs text-slate-500">Casos que dependen directamente de ti.</p>
@@ -37,7 +41,7 @@
     <article class="flex flex-col gap-2 rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
       <div class="flex items-center justify-between">
         <span class="text-sm font-semibold text-slate-600 uppercase tracking-wider">Tickets activos</span>
-        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-sky-50 text-sky-500"><i class="bi bi-activity"></i></span>
+        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-emerald-100 text-emerald-600"><i class="bi bi-activity"></i></span>
       </div>
       <p class="text-4xl font-semibold text-slate-900">{{ tech_counters.total }}</p>
       <p class="text-xs text-slate-500">Todo lo que está en movimiento hoy.</p>
@@ -45,7 +49,7 @@
     <article class="flex flex-col gap-2 rounded-3xl border border-slate-200 bg-white p-5 shadow-sm">
       <div class="flex items-center justify-between">
         <span class="text-sm font-semibold text-slate-600 uppercase tracking-wider">Por asignar</span>
-        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-amber-50 text-amber-500"><i class="bi bi-hourglass-split"></i></span>
+        <span class="flex h-10 w-10 items-center justify-center rounded-full bg-amber-100 text-amber-600"><i class="bi bi-hourglass-split"></i></span>
       </div>
       <p class="text-4xl font-semibold text-slate-900">{{ tech_counters.unassigned }}</p>
       <p class="text-xs text-slate-500">Agarra los pendientes para que nadie quede botado.</p>
@@ -57,7 +61,7 @@
   <section aria-label="Bandejas rápidas" class="flex flex-wrap items-center gap-2">
     {% for option in inbox_links %}
       <a href="{{ option.url }}"
-         class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-medium transition {% if current_inbox == option.value %}bg-indigo-600 text-white shadow{% else %}bg-white text-slate-600 hover:border-blue-200 hover:text-blue-600{% endif %}">
+         class="inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 text-sm font-medium transition {% if current_inbox == option.value %}bg-indigo-600 text-white shadow{% else %}bg-white text-slate-600 hover:border-indigo-200 hover:text-indigo-600{% endif %}">
         <i class="bi bi-inbox"></i>
         {{ option.label }}
       </a>
@@ -69,15 +73,15 @@
     <aside class="space-y-6">
       <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
         <h2 class="text-lg font-semibold text-slate-900">Filtros</h2>
-        <p class="mt-1 text-sm text-slate-500">Afinemos la búsqueda para encontrar rápido el ticket que necesitas.</p>
+        <p class="mt-1 text-sm text-slate-500">Afinemos la búsqueda para encontrar altiro el ticket que necesitas.</p>
         <form method="get" class="mt-4 space-y-4 text-sm">
           <div class="space-y-1">
             <label class="text-xs font-semibold uppercase text-slate-500" for="buscar">Buscar</label>
-            <input id="buscar" name="q" value="{{ filters.q }}" class="w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100" placeholder="Código, título o descripción" />
+            <input id="buscar" name="q" value="{{ filters.q }}" class="w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" placeholder="Código, título o descripción" />
           </div>
           <div class="space-y-1">
             <label class="text-xs font-semibold uppercase text-slate-500" for="estado">Estado</label>
-            <select id="estado" name="status" class="w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100">
+            <select id="estado" name="status" class="w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200">
               <option value="" {% if not filters.status %}selected{% endif %}>(Todos)</option>
               {% for key, label in statuses %}
                 <option value="{{ key }}" {% if filters.status == key %}selected{% endif %}>{{ label }}</option>
@@ -86,11 +90,11 @@
           </div>
           <div class="space-y-1">
             <label class="text-xs font-semibold uppercase text-slate-500" for="categoria">Categoría (ID)</label>
-            <input id="categoria" name="category" value="{{ filters.category }}" class="w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100" placeholder="Ej: 1" />
+            <input id="categoria" name="category" value="{{ filters.category }}" class="w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" placeholder="Ej: 1" />
           </div>
           <div class="space-y-1">
             <label class="text-xs font-semibold uppercase text-slate-500" for="prioridad">Prioridad</label>
-            <select id="prioridad" name="priority" class="w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100">
+            <select id="prioridad" name="priority" class="w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200">
               <option value="" {% if not filters.priority %}selected{% endif %}>(Todas)</option>
               {% for p in priorities %}
                 <option value="{{ p.id }}" {% if filters.priority|stringformat:'s' == p.id|stringformat:'s' %}selected{% endif %}>{{ p.name }}</option>
@@ -99,30 +103,30 @@
           </div>
           <div class="flex items-center justify-between gap-3">
             <label class="inline-flex items-center gap-2 text-xs font-semibold uppercase text-slate-500">
-              <input type="checkbox" name="alerts" value="1" class="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500" {% if filters.alerts %}checked{% endif %}>
+              <input type="checkbox" name="alerts" value="1" class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500" {% if filters.alerts %}checked{% endif %}>
               Alertas SLA
             </label>
             <label class="inline-flex items-center gap-2 text-xs font-semibold uppercase text-slate-500">
-              <input type="checkbox" name="hide_closed" value="1" class="h-4 w-4 rounded border-slate-300 text-blue-600 focus:ring-blue-500" {% if filters.hide_closed == '1' %}checked{% endif %}>
+              <input type="checkbox" name="hide_closed" value="1" class="h-4 w-4 rounded border-slate-300 text-indigo-600 focus:ring-indigo-500" {% if filters.hide_closed == '1' %}checked{% endif %}>
               Ocultar cerrados
             </label>
           </div>
           <div class="space-y-1">
             <label class="text-xs font-semibold uppercase text-slate-500" for="pagina">Por página</label>
-            <input id="pagina" name="page_size" value="{{ page_size }}" class="w-24 rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100" />
+            <input id="pagina" name="page_size" value="{{ page_size }}" class="w-24 rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" />
           </div>
           <div class="flex flex-wrap items-center gap-2">
             <button class="btn inline-flex items-center gap-2 rounded-full bg-indigo-600 px-4 py-2 font-semibold text-white shadow hover:bg-indigo-700" type="submit">
               <i class="bi bi-funnel"></i> Aplicar
             </button>
-            <a href="{% url 'tickets_home' %}" class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 font-semibold text-slate-600 hover:border-blue-200 hover:text-blue-600">
+            <a href="{% url 'tickets_home' %}" class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-4 py-2 font-semibold text-slate-600 hover:border-indigo-200 hover:text-indigo-600">
               <i class="bi bi-eraser"></i> Limpiar
             </a>
           </div>
         </form>
       </article>
       <p class="rounded-2xl border border-slate-200 bg-white p-4 text-xs text-slate-500">
-        Consejo: deja anotado todo lo que vaya cambiando para que el resto del equipo esté al tanto de inmediato.
+        Consejo chileno: deja anotado todo lo que vaya cambiando para que el resto del equipo caché al tiro el contexto.
       </p>
     </aside>
 
@@ -174,7 +178,7 @@
             <tbody class="divide-y divide-slate-100">
               {% for t in tickets %}
               <tr
-                class="group cursor-pointer transition hover:bg-blue-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-blue-500 {% if t.is_overdue %}bg-rose-50 hover:bg-rose-100{% elif t.is_warning %}bg-amber-50 hover:bg-amber-100{% endif %}"
+                class="group cursor-pointer transition hover:bg-indigo-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-0 focus-visible:outline-indigo-500 {% if t.is_overdue %}bg-rose-50/70 hover:bg-rose-100/80{% elif t.is_warning %}bg-amber-50/70 hover:bg-amber-100/80{% endif %}"
                 data-ticket-row
                 data-href="{% url 'ticket_detail' t.id %}"
                 tabindex="0"
@@ -182,14 +186,14 @@
                 aria-label="Abrir ticket {{ t.code }}"
               >
                 <td class="px-4 py-3 font-semibold text-indigo-600">
-                  <a class="inline-flex items-center gap-1 rounded-full bg-blue-50 px-3 py-1 text-sm font-semibold text-indigo-600 transition group-hover:bg-blue-100 focus-visible:outline-none" href="{% url 'ticket_detail' t.id %}">
+                  <a class="inline-flex items-center gap-1 rounded-full bg-indigo-50 px-3 py-1 text-sm font-semibold text-indigo-700 transition group-hover:bg-indigo-100 focus-visible:outline-none" href="{% url 'ticket_detail' t.id %}">
                     <i class="bi bi-hash"></i>
                     {{ t.code }}
                   </a>
                 </td>
                 <td class="px-4 py-3 text-slate-700">{{ t.title }}</td>
                 <td class="px-4 py-3">
-                  <span class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold {% if t.status == 'OPEN' %}bg-blue-50 text-blue-600{% elif t.status == 'IN_PROGRESS' %}bg-amber-50 text-amber-600{% elif t.status == 'RESOLVED' %}bg-emerald-50 text-emerald-600{% else %}bg-slate-50 text-slate-600{% endif %}">
+                  <span class="inline-flex items-center gap-2 rounded-full px-3 py-1 text-xs font-semibold {% if t.status == 'OPEN' %}bg-sky-100 text-sky-700{% elif t.status == 'IN_PROGRESS' %}bg-amber-100 text-amber-700{% elif t.status == 'RESOLVED' %}bg-emerald-100 text-emerald-700{% else %}bg-slate-100 text-slate-600{% endif %}">
                     <i class="bi bi-circle-fill text-[8px]"></i>
                     {{ t.get_status_display }}
                   </span>
@@ -198,11 +202,11 @@
                   <span class="inline-flex items-center gap-1 text-slate-600">
                     {{ t.get_kind_display }}
                     {% if t.kind == 'INCIDENT' %}
-                      <i class="bi bi-exclamation-triangle-fill text-rose-400" title="Incidente: interrupción o degradación del servicio."></i>
+                      <i class="bi bi-exclamation-triangle-fill text-rose-500" title="Incidente: interrupción o degradación del servicio."></i>
                     {% elif t.kind == 'REQUEST' %}
-                      <i class="bi bi-clipboard-check text-emerald-500" title="Solicitud: requerimiento o petición de servicio."></i>
+                      <i class="bi bi-clipboard-check text-emerald-600" title="Solicitud: requerimiento o petición de servicio."></i>
                     {% else %}
-                      <i class="bi bi-info-circle text-slate-500" title="Clasificación del ticket"></i>
+                      <i class="bi bi-info-circle text-gray-500" title="Clasificación del ticket"></i>
                     {% endif %}
                   </span>
                 </td>
@@ -211,12 +215,12 @@
                 <td class="px-4 py-3 text-slate-600">{% if t.assigned_to %}{{ t.assigned_to.username }}{% else %}<span class="text-slate-400">Sin asignar</span>{% endif %}</td>
                 <td class="px-4 py-3 space-y-1">
                   {% if t.is_overdue %}
-                    <span class="inline-flex items-center gap-2 rounded-full bg-rose-50 px-3 py-1 text-xs font-semibold text-rose-600"><i class="bi bi-alarm"></i> SLA vencido</span>
+                    <span class="inline-flex items-center gap-2 rounded-full bg-rose-100 px-3 py-1 text-xs font-semibold text-rose-600"><i class="bi bi-alarm"></i> SLA vencido</span>
                   {% elif t.is_warning %}
-                    <span class="inline-flex items-center gap-2 rounded-full bg-amber-50 px-3 py-1 text-xs font-semibold text-amber-600"><i class="bi bi-hourglass"></i> Por vencer (~{{ t.remaining_hours|floatformat:0 }}h)</span>
+                    <span class="inline-flex items-center gap-2 rounded-full bg-amber-100 px-3 py-1 text-xs font-semibold text-amber-700"><i class="bi bi-hourglass"></i> Por vencer (~{{ t.remaining_hours|floatformat:0 }}h)</span>
                   {% endif %}
                   {% if t.is_critical %}
-                    <span class="inline-flex items-center gap-2 rounded-full bg-rose-500 px-3 py-1 text-xs font-semibold text-white"><i class="bi bi-lightning"></i> Crítico</span>
+                    <span class="inline-flex items-center gap-2 rounded-full bg-rose-600 px-3 py-1 text-xs font-semibold text-white"><i class="bi bi-lightning"></i> Crítico</span>
                   {% endif %}
                 </td>
                 <td class="px-4 py-3 text-slate-500">{{ t.created_at }}</td>
@@ -225,7 +229,7 @@
               <tr>
                 <td class="px-4 py-8 text-center text-sm text-slate-500" colspan="9">
                   <div class="flex flex-col items-center gap-2">
-                    <i class="bi bi-emoji-smile text-2xl text-blue-400"></i>
+                    <i class="bi bi-emoji-smile text-2xl text-indigo-400"></i>
                     <p>No tienes tickets en esta vista. Aprovecha de tomarte un cafecito.</p>
                   </div>
                 </td>
@@ -243,15 +247,15 @@
           <nav class="flex flex-wrap items-center gap-2" aria-label="Paginación">
             {% with qsp="q="|add:filters.q|urlencode|add:"&status="|add:filters.status|add:"&category="|add:filters.category|add:"&priority="|add:filters.priority|add:"&alerts="|add:filters.alerts|add:"&hide_closed="|add:filters.hide_closed|add:"&page_size="|add:page_size %}
               {% if page_obj.has_previous %}
-                <a class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:border-blue-200 hover:text-blue-600" href="?{{ qsp }}&page=1">&laquo; Primera</a>
-                <a class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:border-blue-200 hover:text-blue-600" href="?{{ qsp }}&page={{ page_obj.previous_page_number }}">Anterior</a>
+                <a class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:border-indigo-200 hover:text-indigo-600" href="?{{ qsp }}&page=1">&laquo; Primera</a>
+                <a class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:border-indigo-200 hover:text-indigo-600" href="?{{ qsp }}&page={{ page_obj.previous_page_number }}">Anterior</a>
               {% else %}
                 <span class="inline-flex items-center gap-2 rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-xs text-slate-400">&laquo; Primera</span>
                 <span class="inline-flex items-center gap-2 rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-xs text-slate-400">Anterior</span>
               {% endif %}
               {% if page_obj.has_next %}
-                <a class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:border-blue-200 hover:text-blue-600" href="?{{ qsp }}&page={{ page_obj.next_page_number }}">Siguiente</a>
-                <a class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:border-blue-200 hover:text-blue-600" href="?{{ qsp }}&page={{ page_obj.paginator.num_pages }}">Última &raquo;</a>
+                <a class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:border-indigo-200 hover:text-indigo-600" href="?{{ qsp }}&page={{ page_obj.next_page_number }}">Siguiente</a>
+                <a class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 text-xs font-semibold text-slate-600 hover:border-indigo-200 hover:text-indigo-600" href="?{{ qsp }}&page={{ page_obj.paginator.num_pages }}">Última &raquo;</a>
               {% else %}
                 <span class="inline-flex items-center gap-2 rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-xs text-slate-400">Siguiente</span>
                 <span class="inline-flex items-center gap-2 rounded-full border border-dashed border-slate-200 px-3 py-1.5 text-xs text-slate-400">Última &raquo;</span>

--- a/mvp-tickets/templates/tickets/new.html
+++ b/mvp-tickets/templates/tickets/new.html
@@ -4,13 +4,13 @@
 {% block title %}Nuevo ticket{% endblock %}
 
 {% block content %}
-{# Formulario principal para levantar un nuevo ticket con copy en español latinoamericano cercano. #}
+{# Formulario principal para levantar un nuevo ticket con copy chileno cercano. #}
 <section class="space-y-8">
-  <article class="rounded-3xl border border-blue-100 bg-gradient-to-br from-indigo-500 via-blue-500 to-sky-400 p-8 text-white shadow">
+  <article class="rounded-3xl border border-emerald-100 bg-gradient-to-br from-emerald-500 via-emerald-400 to-teal-500 p-8 text-white shadow">
     <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
       <div class="max-w-2xl space-y-2">
         <h1 class="text-3xl font-bold tracking-tight">Levantemos tu ticket</h1>
-        <p class="text-sm text-blue-100 md:text-base">Cuéntanos qué pasó y te apoyamos de inmediato. Mientras más detalle nos des, más rápido lo solucionamos.</p>
+        <p class="text-sm text-emerald-100 md:text-base">Cuéntanos qué pasó y te apoyamos al tiro. Mientras más detalle nos des, más rápido lo solucionamos.</p>
       </div>
       <span class="inline-flex items-center gap-2 rounded-full bg-white/20 px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em]">Paso a paso</span>
     </div>
@@ -31,34 +31,34 @@
       <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div class="space-y-1">
           <label class="text-xs font-semibold uppercase text-slate-500" for="titulo">Título</label>
-          {{ form.title|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"|attr:"id=titulo" }}
+          {{ form.title|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-100"|attr:"id=titulo" }}
           {% if form.title.errors %}<div class="text-xs text-rose-600">{{ form.title.errors }}</div>{% endif %}
         </div>
         <div class="space-y-1">
           <label class="text-xs font-semibold uppercase text-slate-500" for="categoria">Categoría</label>
-          {{ form.category|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"|attr:"id=categoria" }}
+          {{ form.category|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-100"|attr:"id=categoria" }}
           {% if form.category.errors %}<div class="text-xs text-rose-600">{{ form.category.errors }}</div>{% endif %}
         </div>
         <div class="space-y-1">
           <label class="text-xs font-semibold uppercase text-slate-500" for="prioridad">Prioridad</label>
-          {{ form.priority|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"|attr:"id=prioridad" }}
+          {{ form.priority|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-100"|attr:"id=prioridad" }}
           {% if form.priority.errors %}<div class="text-xs text-rose-600">{{ form.priority.errors }}</div>{% endif %}
         </div>
         <div class="space-y-1">
           <label class="text-xs font-semibold uppercase text-slate-500" for="tipo">Tipo de ticket</label>
-          {{ form.kind|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"|attr:"id=tipo" }}
+          {{ form.kind|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-100"|attr:"id=tipo" }}
           <p class="text-[11px] text-slate-500">Incidente: se cayó algo o dejó de funcionar · Solicitud: necesitas algo nuevo.</p>
           {% if form.kind.errors %}<div class="text-xs text-rose-600">{{ form.kind.errors }}</div>{% endif %}
         </div>
         <div class="space-y-1">
           <label class="text-xs font-semibold uppercase text-slate-500" for="area">Área</label>
-          {{ form.area|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"|attr:"id=area" }}
+          {{ form.area|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-100"|attr:"id=area" }}
           {% if form.area.errors %}<div class="text-xs text-rose-600">{{ form.area.errors }}</div>{% endif %}
         </div>
         {% if form.assignee %}
         <div class="space-y-1">
           <label class="text-xs font-semibold uppercase text-slate-500" for="asignar">Asignar a (opcional)</label>
-          {{ form.assignee|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100"|attr:"id=asignar" }}
+          {{ form.assignee|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-100"|attr:"id=asignar" }}
           {% if form.assignee.errors %}<div class="text-xs text-rose-600">{{ form.assignee.errors }}</div>{% endif %}
         </div>
         {% endif %}
@@ -68,15 +68,15 @@
     <fieldset class="space-y-3">
       <legend class="text-lg font-semibold text-slate-900">Cuéntanos el detalle</legend>
       <p class="text-sm text-slate-500">Relata qué pasó, cómo te afecta y si ya probaste alguna solución. Mientras más contexto, mejor.</p>
-      {{ form.description|add_class:"w-full rounded-2xl border border-slate-200 px-4 py-3 focus:border-blue-400 focus:outline-none focus:ring-2 focus:ring-blue-100" }}
+      {{ form.description|add_class:"w-full rounded-2xl border border-slate-200 px-4 py-3 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-100" }}
       {% if form.description.errors %}<div class="text-xs text-rose-600">{{ form.description.errors }}</div>{% endif %}
     </fieldset>
 
     <div class="flex flex-wrap items-center gap-3 pt-2">
-      <button class="btn inline-flex items-center gap-2 rounded-full bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-700" type="submit">
+      <button class="btn inline-flex items-center gap-2 rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-600" type="submit">
         <i class="bi bi-send"></i> Crear ticket
       </button>
-      <a href="{% url 'tickets_home' %}" class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-5 py-2 text-sm font-semibold text-slate-600 hover:border-blue-200 hover:text-blue-600">
+      <a href="{% url 'tickets_home' %}" class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-5 py-2 text-sm font-semibold text-slate-600 hover:border-emerald-200 hover:text-emerald-600">
         <i class="bi bi-arrow-left"></i> Volver sin guardar
       </a>
     </div>


### PR DESCRIPTION
## Summary
- return the header navigation to the previous layout while keeping the upgraded admin dropdown
- allow main page content to span the full width for roomier layouts
- bring back the earlier visual treatment for the ticket list and creation form so they feel more polished

## Testing
- python manage.py check *(fails: Django is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ddbc8521bc832195f4e75141ddf0ce