### PR TITLE
Restyle auto-assignment screens

### DIFF
--- a/mvp-tickets/templates/tickets/auto_rules/form.html
+++ b/mvp-tickets/templates/tickets/auto_rules/form.html
@@ -1,35 +1,57 @@
 {% extends "base.html" %}
+{% load widget_tweaks %}
 {% block title %}{% if is_new %}Nueva{% else %}Editar{% endif %} regla{% endblock %}
 {% block content %}
-<h1 class="text-xl font-semibold mb-4">{% if is_new %}Nueva{% else %}Editar{% endif %} regla</h1>
+<div class="space-y-8">
+  <header class="rounded-3xl border border-indigo-100 bg-gradient-to-br from-indigo-600 via-blue-500 to-sky-400 p-6 text-white shadow">
+    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+      <div class="space-y-2">
+        <p class="inline-flex items-center gap-2 rounded-full bg-white/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em]">Automatización</p>
+        <h1 class="text-3xl font-bold tracking-tight">{% if is_new %}Nueva{% else %}Editar{% endif %} regla</h1>
+        <p class="max-w-xl text-sm text-blue-100">Define a quién llegará cada ticket de forma automática según la categoría o el área.</p>
+      </div>
+      <a href="{% url 'auto_rules_list' %}" class="btn inline-flex items-center gap-2 rounded-full border border-white/40 px-5 py-2 text-sm font-semibold text-white/90 hover:bg-white/15">
+        <i class="bi bi-arrow-left"></i>
+        Volver a reglas
+      </a>
+    </div>
+  </header>
 
-<form method="post" class="bg-white rounded-xl shadow p-4 space-y-4">
-  {% csrf_token %}
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-    <div>
-      <label class="block text-xs">Categoría (opcional)</label>
-      {{ form.category }}
-      {% if form.category.errors %}<div class="text-red-600 text-xs">{{ form.category.errors }}</div>{% endif %}
+  <form method="post" class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm space-y-6">
+    {% csrf_token %}
+    <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
+      <div class="space-y-1">
+        <label class="text-xs font-semibold uppercase text-slate-500" for="id_category">Categoría (opcional)</label>
+        {{ form.category|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100" }}
+        {% if form.category.errors %}<div class="text-xs text-rose-600">{{ form.category.errors }}</div>{% endif %}
+      </div>
+      <div class="space-y-1">
+        <label class="text-xs font-semibold uppercase text-slate-500" for="id_area">Área (opcional)</label>
+        {{ form.area|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100" }}
+        {% if form.area.errors %}<div class="text-xs text-rose-600">{{ form.area.errors }}</div>{% endif %}
+      </div>
+      <div class="space-y-1 md:col-span-2">
+        <label class="text-xs font-semibold uppercase text-slate-500" for="id_tech">Técnico</label>
+        {{ form.tech|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100" }}
+        {% if form.tech.errors %}<div class="text-xs text-rose-600">{{ form.tech.errors }}</div>{% endif %}
+      </div>
+      <div class="md:col-span-2">
+        <label class="inline-flex items-center gap-2 text-xs font-semibold uppercase tracking-[0.25em] text-slate-500">
+          {{ form.is_active }} Activa
+        </label>
+      </div>
     </div>
-    <div>
-      <label class="block text-xs">Área (opcional)</label>
-      {{ form.area }}
-      {% if form.area.errors %}<div class="text-red-600 text-xs">{{ form.area.errors }}</div>{% endif %}
-    </div>
-    <div>
-      <label class="block text-xs">Técnico</label>
-      {{ form.tech }}
-      {% if form.tech.errors %}<div class="text-red-600 text-xs">{{ form.tech.errors }}</div>{% endif %}
-    </div>
-    <div class="flex items-center mt-6">
-      {{ form.is_active }} <span class="text-sm">Activa</span>
-      {% if form.is_active.errors %}<div class="text-red-600 text-xs ml-2">{{ form.is_active.errors }}</div>{% endif %}
-    </div>
-  </div>
 
-  <div class="flex items-center gap-2">
-    <button class="bg-blue-600 text-white px-3 py-1.5 rounded text-sm">Guardar</button>
-    <a href="{% url 'auto_rules_list' %}" class="px-3 py-1.5 border rounded text-sm">Cancelar</a>
-  </div>
-</form>
+    <div class="flex flex-wrap items-center justify-end gap-3">
+      <a href="{% url 'auto_rules_list' %}" class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-5 py-2 text-sm font-semibold text-slate-600 hover:border-indigo-200 hover:text-indigo-600">
+        <i class="bi bi-x-circle"></i>
+        Cancelar
+      </a>
+      <button class="btn inline-flex items-center gap-2 rounded-full bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-700" type="submit">
+        <i class="bi bi-check2-circle"></i>
+        {% if is_new %}Crear regla{% else %}Guardar cambios{% endif %}
+      </button>
+    </div>
+  </form>
+</div>
 {% endblock %}

--- a/mvp-tickets/templates/tickets/auto_rules/list.html
+++ b/mvp-tickets/templates/tickets/auto_rules/list.html
@@ -1,49 +1,76 @@
 {% extends "base.html" %}
-{% block title %}Reglas de auto-asignación{% endblock %}
+{% block title %}Auto-asignación{% endblock %}
 {% block content %}
-<div class="flex items-center justify-between mb-4">
-  <h1 class="text-xl font-semibold">Reglas de auto-asignación</h1>
-  <a href="{% url 'auto_rule_create' %}" class="bg-blue-600 text-white px-3 py-1.5 rounded text-sm">Nueva regla</a>
-</div>
+<div class="space-y-8">
+  <header class="rounded-3xl border border-indigo-100 bg-gradient-to-br from-indigo-600 via-blue-500 to-sky-400 p-6 text-white shadow">
+    <div class="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+      <div class="space-y-2">
+        <p class="inline-flex items-center gap-2 rounded-full bg-white/20 px-3 py-1 text-xs font-semibold uppercase tracking-[0.35em]">Automatización</p>
+        <h1 class="text-3xl font-bold tracking-tight">Reglas de auto-asignación</h1>
+        <p class="max-w-xl text-sm text-blue-100">Configura combinaciones de categoría, área y técnico para agilizar el enrutamiento.</p>
+      </div>
+      <a href="{% url 'auto_rule_create' %}" class="btn inline-flex items-center gap-2 rounded-full bg-white px-5 py-2 text-sm font-semibold text-indigo-700 shadow-lg shadow-indigo-900/20 transition hover:bg-indigo-50">
+        <i class="bi bi-magic"></i>
+        Nueva regla
+      </a>
+    </div>
+  </header>
 
-<table class="w-full bg-white rounded-xl shadow overflow-hidden text-sm">
-  <thead class="bg-gray-100">
-    <tr>
-      <th class="text-left p-2">Categoría</th>
-      <th class="text-left p-2">Área</th>
-      <th class="text-left p-2">Técnico</th>
-      <th class="text-left p-2">Estado</th>
-      <th class="text-left p-2 w-48">Acciones</th>
-    </tr>
-  </thead>
-  <tbody>
-    {% for r in rules %}
-    <tr class="border-t">
-      <td class="p-2">{{ r.category.name|default:"—" }}</td>
-      <td class="p-2">{{ r.area.name|default:"—" }}</td>
-      <td class="p-2">{{ r.tech.username }}</td>
-      <td class="p-2">
-        {% if r.is_active %}
-          <span class="text-xs px-2 py-0.5 rounded bg-green-100 text-green-700 border border-green-200">Activa</span>
-        {% else %}
-          <span class="text-xs px-2 py-0.5 rounded bg-gray-100 text-gray-700 border">Inactiva</span>
-        {% endif %}
-      </td>
-      <td class="p-2 space-x-1">
-        <a href="{% url 'auto_rule_edit' r.id %}" class="px-2 py-1 border rounded">Editar</a>
-        <form method="post" action="{% url 'auto_rule_toggle' r.id %}" class="inline">
-          {% csrf_token %}
-          <button class="px-2 py-1 border rounded">{{ r.is_active|yesno:"Desactivar,Activar" }}</button>
-        </form>
-        <form method="post" action="{% url 'auto_rule_delete' r.id %}" class="inline" onsubmit="return confirm('¿Eliminar regla?')">
-          {% csrf_token %}
-          <button class="px-2 py-1 border rounded text-red-700">Eliminar</button>
-        </form>
-      </td>
-    </tr>
-    {% empty %}
-    <tr><td class="p-3" colspan="5">Sin reglas.</td></tr>
-    {% endfor %}
-  </tbody>
-</table>
+  <article class="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm">
+    <div class="flex items-center justify-between border-b border-slate-100 px-6 py-4">
+      <h2 class="text-lg font-semibold text-slate-900">Listado de reglas</h2>
+      <p class="text-xs text-slate-500">Edita o activa/desactiva según la disponibilidad del equipo.</p>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="min-w-full divide-y divide-slate-100 text-sm">
+        <thead class="bg-slate-50 text-xs uppercase tracking-wide text-slate-600">
+          <tr>
+            <th scope="col" class="px-4 py-3 text-left">Categoría</th>
+            <th scope="col" class="px-4 py-3 text-left">Área</th>
+            <th scope="col" class="px-4 py-3 text-left">Técnico</th>
+            <th scope="col" class="px-4 py-3 text-left">Activa</th>
+            <th scope="col" class="px-4 py-3 text-left">Acciones</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-slate-100">
+          {% for r in rules %}
+          <tr class="transition hover:bg-slate-50">
+            <td class="px-4 py-3 text-slate-700">{{ r.category.name|default:"—" }}</td>
+            <td class="px-4 py-3 text-slate-700">{{ r.area.name|default:"—" }}</td>
+            <td class="px-4 py-3 font-medium text-slate-800">{{ r.tech.username }}</td>
+            <td class="px-4 py-3">
+              {% if r.is_active %}
+                <span class="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-3 py-1 text-xs font-semibold text-emerald-700"><i class="bi bi-check-circle"></i> Sí</span>
+              {% else %}
+                <span class="inline-flex items-center gap-1 rounded-full bg-slate-100 px-3 py-1 text-xs font-semibold text-slate-500"><i class="bi bi-pause-circle"></i> No</span>
+              {% endif %}
+            </td>
+            <td class="px-4 py-3">
+              <div class="flex flex-wrap items-center gap-3 text-xs font-semibold">
+                <a href="{% url 'auto_rule_edit' r.id %}" class="text-indigo-600 hover:text-indigo-800"><i class="bi bi-pencil"></i> Editar</a>
+                <form method="post" action="{% url 'auto_rule_toggle' r.id %}" class="inline" onsubmit="return confirm('¿Quieres alternar el estado de la regla?');">
+                  {% csrf_token %}
+                  <button class="text-amber-600 hover:text-amber-700" title="Activar/Desactivar">
+                    <i class="bi bi-arrow-repeat"></i> Alternar
+                  </button>
+                </form>
+                <form method="post" action="{% url 'auto_rule_delete' r.id %}" class="inline" onsubmit="return confirm('¿Eliminar regla?');">
+                  {% csrf_token %}
+                  <button class="text-rose-600 hover:text-rose-700">
+                    <i class="bi bi-trash"></i> Eliminar
+                  </button>
+                </form>
+              </div>
+            </td>
+          </tr>
+          {% empty %}
+          <tr>
+            <td class="px-4 py-6 text-center text-sm text-slate-500" colspan="5">Todavía no se han definido reglas automáticas.</td>
+          </tr>
+          {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </article>
+</div>
 {% endblock %}


### PR DESCRIPTION
## Summary
- refresh the auto-assignment list view to match the new dashboard styling
- modernize the auto-assignment form layout and inputs with shared components

## Testing
- not run (Django dependencies not installed in container)


------
https://chatgpt.com/codex/tasks/task_e_68ddc274c2e0832195153ab162a0a15f