### PR TITLE
Adjust report filters and ticket form styling

### DIFF
--- a/mvp-tickets/templates/reports/dashboard.html
+++ b/mvp-tickets/templates/reports/dashboard.html
@@ -27,15 +27,15 @@
       <div class="grid gap-4 text-sm md:grid-cols-5">
         <div class="flex flex-col gap-1">
           <label class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Desde</label>
-          <input type="date" name="from" value="{{ from }}" class="rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" />
+          <input type="date" name="from" value="{{ from }}" class="rounded-xl border border-slate-200 px-3 py-2 text-slate-900 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" />
         </div>
         <div class="flex flex-col gap-1">
           <label class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Hasta</label>
-          <input type="date" name="to" value="{{ to }}" class="rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" />
+          <input type="date" name="to" value="{{ to }}" class="rounded-xl border border-slate-200 px-3 py-2 text-slate-900 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200" />
         </div>
         <div class="flex flex-col gap-1">
           <label class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Tipo de reporte</label>
-          <select name="type" class="rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200">
+          <select name="type" class="rounded-xl border border-slate-200 px-3 py-2 text-slate-900 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200">
             <option value="total" {% if report_type == 'total' %}selected{% endif %}>Total</option>
             <option value="categoria" {% if report_type == 'categoria' %}selected{% endif %}>Por categoría</option>
             <option value="promedio" {% if report_type == 'promedio' %}selected{% endif %}>Tiempo promedio</option>
@@ -45,7 +45,7 @@
         </div>
         <div class="flex flex-col gap-1">
           <label class="text-xs font-semibold uppercase tracking-[0.2em] text-slate-500">Técnico</label>
-          <select name="tech" class="rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200">
+          <select name="tech" class="rounded-xl border border-slate-200 px-3 py-2 text-slate-900 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-200">
             <option value="" {% if not tech_selected %}selected{% endif %}>(Todos)</option>
             {% for t in techs %}
             <option value="{{ t.id }}" {% if tech_selected == t.id|stringformat:'s' %}selected{% endif %}>{{ t.username }}</option>
@@ -133,10 +133,41 @@
   {{ chart_hist|json_script:"chart_hist_data" }}
   {{ chart_cat_slow|json_script:"chart_cat_slow_data" }}
   <script>
-    const COLORS = [
-      "#bae6fd", "#fde68a", "#a7f3d0", "#fecdd3", "#ddd6fe",
-      "#fbcfe8", "#c4b5fd", "#99f6e4", "#d9f99d", "#fcd34d"
-    ];
+    const PALETTES = {
+      chartCat: ["#0ea5e9", "#38bdf8", "#0284c7", "#7dd3fc", "#0c4a6e"],
+      chartPri: ["#059669", "#34d399", "#10b981", "#047857", "#6ee7b7"],
+      chartTech: ["#f59e0b", "#f97316", "#fb923c", "#fbbf24", "#facc15"],
+      chartHist: ["#ec4899", "#f472b6", "#be185d", "#f9a8d4", "#db2777"],
+      chartCatSlow: ["#6366f1", "#4f46e5", "#818cf8", "#4338ca", "#a5b4fc"],
+      default: ["#1d4ed8", "#2563eb", "#3b82f6", "#60a5fa", "#93c5fd"],
+    };
+
+    function hexToRgba(hex, alpha = 0.85) {
+      if (!hex) return `rgba(15, 23, 42, ${alpha})`;
+      let sanitized = hex.replace("#", "");
+      if (sanitized.length === 3) {
+        sanitized = sanitized.split("").map((char) => char + char).join("");
+      }
+      const intVal = parseInt(sanitized, 16);
+      const r = (intVal >> 16) & 255;
+      const g = (intVal >> 8) & 255;
+      const b = intVal & 255;
+      return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+    }
+
+    function paletteFor(id) {
+      return PALETTES[id] || PALETTES.default;
+    }
+
+    function withAlpha(color, alpha = 0.75) {
+      if (typeof color !== "string") {
+        return hexToRgba("#0f172a", alpha);
+      }
+      if (color.startsWith("#")) {
+        return hexToRgba(color, alpha);
+      }
+      return color;
+    }
 
     function parseData(id) {
       const el = document.getElementById(id);
@@ -152,6 +183,10 @@
       if (!canvas) return null;
       const ctx = canvas.getContext("2d");
       const max = Math.max(1, ...dataset.data);
+      const palette = paletteFor(canvasId);
+      const borderColors = dataset.data.map((_, index) => palette[index % palette.length]);
+      const backgroundColors = borderColors.map((color) => withAlpha(color, 0.65));
+
       return new Chart(ctx, {
         type: "bar",
         data: {
@@ -160,8 +195,8 @@
             {
               label: title,
               data: dataset.data,
-              backgroundColor: dataset.data.map((_, index) => COLORS[index % COLORS.length]),
-              borderColor: dataset.data.map((_, index) => COLORS[index % COLORS.length]),
+              backgroundColor: backgroundColors,
+              borderColor: borderColors,
               borderWidth: 1,
             },
           ],

--- a/mvp-tickets/templates/tickets/new.html
+++ b/mvp-tickets/templates/tickets/new.html
@@ -6,11 +6,11 @@
 {% block content %}
 {# Formulario principal para levantar un nuevo ticket con un tono cercano en español latinoamericano. #}
 <section class="space-y-8">
-  <article class="rounded-3xl border border-emerald-100 bg-gradient-to-br from-emerald-500 via-emerald-400 to-teal-500 p-8 text-white shadow">
+  <article class="rounded-3xl border border-indigo-100 bg-gradient-to-br from-indigo-600 via-indigo-500 to-sky-500 p-8 text-white shadow">
     <div class="flex flex-col gap-3 md:flex-row md:items-end md:justify-between">
       <div class="max-w-2xl space-y-2">
         <h1 class="text-3xl font-bold tracking-tight">Levantemos tu ticket</h1>
-        <p class="text-sm text-emerald-100 md:text-base">Cuéntanos qué pasó y te apoyamos de inmediato. Mientras más detalle nos des, más rápido lo solucionamos.</p>
+        <p class="text-sm text-indigo-100 md:text-base">Cuéntanos qué pasó y te apoyamos de inmediato. Mientras más detalle nos des, más rápido lo solucionamos.</p>
       </div>
       <span class="inline-flex items-center gap-2 rounded-full bg-white/20 px-4 py-1 text-xs font-semibold uppercase tracking-[0.4em]">Paso a paso</span>
     </div>
@@ -31,34 +31,34 @@
       <div class="grid grid-cols-1 gap-4 md:grid-cols-2">
         <div class="space-y-1">
           <label class="text-xs font-semibold uppercase text-slate-500" for="titulo">Título</label>
-          {{ form.title|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-100"|attr:"id=titulo" }}
+          {{ form.title|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100"|attr:"id=titulo" }}
           {% if form.title.errors %}<div class="text-xs text-rose-600">{{ form.title.errors }}</div>{% endif %}
         </div>
         <div class="space-y-1">
           <label class="text-xs font-semibold uppercase text-slate-500" for="categoria">Categoría</label>
-          {{ form.category|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-100"|attr:"id=categoria" }}
+          {{ form.category|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100"|attr:"id=categoria" }}
           {% if form.category.errors %}<div class="text-xs text-rose-600">{{ form.category.errors }}</div>{% endif %}
         </div>
         <div class="space-y-1">
           <label class="text-xs font-semibold uppercase text-slate-500" for="prioridad">Prioridad</label>
-          {{ form.priority|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-100"|attr:"id=prioridad" }}
+          {{ form.priority|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100"|attr:"id=prioridad" }}
           {% if form.priority.errors %}<div class="text-xs text-rose-600">{{ form.priority.errors }}</div>{% endif %}
         </div>
         <div class="space-y-1">
           <label class="text-xs font-semibold uppercase text-slate-500" for="tipo">Tipo de ticket</label>
-          {{ form.kind|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-100"|attr:"id=tipo" }}
+          {{ form.kind|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100"|attr:"id=tipo" }}
           <p class="text-[11px] text-slate-500">Incidente: se cayó algo o dejó de funcionar · Solicitud: necesitas algo nuevo.</p>
           {% if form.kind.errors %}<div class="text-xs text-rose-600">{{ form.kind.errors }}</div>{% endif %}
         </div>
         <div class="space-y-1">
           <label class="text-xs font-semibold uppercase text-slate-500" for="area">Área</label>
-          {{ form.area|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-100"|attr:"id=area" }}
+          {{ form.area|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100"|attr:"id=area" }}
           {% if form.area.errors %}<div class="text-xs text-rose-600">{{ form.area.errors }}</div>{% endif %}
         </div>
         {% if form.assignee %}
         <div class="space-y-1">
           <label class="text-xs font-semibold uppercase text-slate-500" for="asignar">Asignar a (opcional)</label>
-          {{ form.assignee|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-100"|attr:"id=asignar" }}
+          {{ form.assignee|add_class:"w-full rounded-xl border border-slate-200 px-3 py-2 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100"|attr:"id=asignar" }}
           {% if form.assignee.errors %}<div class="text-xs text-rose-600">{{ form.assignee.errors }}</div>{% endif %}
         </div>
         {% endif %}
@@ -68,15 +68,15 @@
     <fieldset class="space-y-3">
       <legend class="text-lg font-semibold text-slate-900">Cuéntanos el detalle</legend>
       <p class="text-sm text-slate-500">Relata qué pasó, cómo te afecta y si ya probaste alguna solución. Mientras más contexto, mejor.</p>
-      {{ form.description|add_class:"w-full rounded-2xl border border-slate-200 px-4 py-3 focus:border-emerald-400 focus:outline-none focus:ring-2 focus:ring-emerald-100" }}
+      {{ form.description|add_class:"w-full rounded-2xl border border-slate-200 px-4 py-3 focus:border-indigo-400 focus:outline-none focus:ring-2 focus:ring-indigo-100" }}
       {% if form.description.errors %}<div class="text-xs text-rose-600">{{ form.description.errors }}</div>{% endif %}
     </fieldset>
 
     <div class="flex flex-wrap items-center gap-3 pt-2">
-      <button class="btn inline-flex items-center gap-2 rounded-full bg-emerald-500 px-5 py-2 text-sm font-semibold text-white shadow hover:bg-emerald-600" type="submit">
+      <button class="btn inline-flex items-center gap-2 rounded-full bg-indigo-600 px-5 py-2 text-sm font-semibold text-white shadow hover:bg-indigo-700" type="submit">
         <i class="bi bi-send"></i> Crear ticket
       </button>
-      <a href="{% url 'tickets_home' %}" class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-5 py-2 text-sm font-semibold text-slate-600 hover:border-emerald-200 hover:text-emerald-600">
+      <a href="{% url 'tickets_home' %}" class="btn inline-flex items-center gap-2 rounded-full border border-slate-200 px-5 py-2 text-sm font-semibold text-slate-600 hover:border-indigo-200 hover:text-indigo-600">
         <i class="bi bi-arrow-left"></i> Volver sin guardar
       </a>
     </div>


### PR DESCRIPTION
## Summary
- ensure report dashboard filters render legible text and recolor charts to match each card
- align the new ticket hero, form focus states, and primary actions with the project's indigo color palette

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e59e28217c83219a123797332a01e4