### PR TITLE
Compact dashboard layout with toggle expansion

### DIFF
--- a/mvp-tickets/templates/base.html
+++ b/mvp-tickets/templates/base.html
@@ -78,26 +78,28 @@
       color: #1d4ed8;
     }
     .page-hero {
-      padding: clamp(1.25rem, 2.5vw, 1.75rem) clamp(1.25rem, 5vw, 2.25rem);
-      border-radius: 1.5rem;
+      padding: clamp(0.85rem, 1.5vw, 1.35rem) clamp(1rem, 4vw, 1.75rem);
+      border-radius: 1.25rem;
       display: flex;
       flex-direction: column;
-      gap: 1.25rem;
+      gap: 0.9rem;
     }
     .page-hero > * {
-      gap: 0.85rem;
+      gap: 0.65rem;
     }
     .page-hero h1 {
-      font-size: clamp(1.5rem, 1.1rem + 1vw, 2.1rem);
+      font-size: clamp(1.35rem, 1rem + 0.6vw, 1.75rem);
       line-height: 1.2;
     }
     .page-hero p {
-      font-size: 0.95rem;
-      line-height: 1.55;
+      font-size: 0.85rem;
+      line-height: 1.45;
     }
     .page-hero .page-hero__meta {
-      font-size: 0.75rem;
-      letter-spacing: 0.25em;
+      font-size: 0.7rem;
+      letter-spacing: 0.18em;
+      padding: 0.35rem 0.65rem;
+      border-radius: 9999px;
     }
     .faq-category-chip[data-active="true"] {
       background: rgba(238, 242, 255, 0.95);

--- a/mvp-tickets/templates/dashboard.html
+++ b/mvp-tickets/templates/dashboard.html
@@ -2,194 +2,301 @@
 {% load tz %}
 {% block title %}Dashboard{% endblock %}
 
+{% block head_extra %}
+<style>
+  .dashboard-shell {
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+    transform-origin: top center;
+    transition: transform 0.35s ease, box-shadow 0.35s ease, padding 0.35s ease, background 0.35s ease, border-color 0.35s ease;
+    border-radius: 2rem;
+    background: linear-gradient(135deg, rgba(241, 245, 249, 0.85), rgba(255, 255, 255, 0.95));
+    padding: 1.75rem;
+    border: 1px solid rgba(148, 163, 184, 0.35);
+    margin: 0 auto;
+  }
+  .dashboard-shell__content {
+    position: relative;
+    z-index: 20;
+  }
+  .dashboard-shell__scrim {
+    position: absolute;
+    inset: 0;
+    z-index: 10;
+    pointer-events: none;
+    background: radial-gradient(circle at top right, rgba(79, 70, 229, 0.18), transparent 45%),
+                linear-gradient(180deg, rgba(15, 23, 42, 0.06), transparent 30%, transparent 70%, rgba(15, 23, 42, 0.08));
+    opacity: 1;
+    transition: opacity 0.35s ease;
+  }
+  .dashboard-shell.dashboard-shell--compact {
+    transform: scale(0.78);
+    max-height: calc(100vh - 6.5rem);
+    box-shadow: 0 35px 80px -45px rgba(15, 23, 42, 0.55);
+  }
+  .dashboard-shell.dashboard-shell--compact .dashboard-shell__scrim {
+    opacity: 1;
+  }
+  .dashboard-shell.dashboard-shell--expanded {
+    transform: scale(1);
+    max-height: none;
+    padding: 0;
+    background: transparent;
+    box-shadow: none;
+    border-color: transparent;
+    overflow: visible;
+  }
+  .dashboard-shell.dashboard-shell--expanded .dashboard-shell__scrim {
+    opacity: 0;
+  }
+  .dashboard-toggle {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    z-index: 50;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.45rem 0.9rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    background: rgba(15, 23, 42, 0.8);
+    color: #f8fafc;
+    box-shadow: 0 18px 40px rgba(15, 23, 42, 0.25);
+    transition: background 0.2s ease, transform 0.2s ease;
+  }
+  .dashboard-toggle:hover {
+    background: rgba(37, 99, 235, 0.9);
+    transform: translateY(-1px);
+  }
+  .dashboard-toggle:focus-visible {
+    outline: 2px solid rgba(37, 99, 235, 0.55);
+    outline-offset: 2px;
+  }
+  .dashboard-toggle__icon {
+    font-size: 0.95rem;
+  }
+  @media (max-width: 1024px) {
+    .dashboard-shell {
+      transform: none !important;
+      max-height: none;
+      padding: 0;
+      background: transparent;
+      box-shadow: none;
+      border-color: transparent;
+    }
+    .dashboard-shell__scrim {
+      display: none;
+    }
+    .dashboard-toggle {
+      display: none;
+    }
+  }
+</style>
+{% endblock %}
+
 {% block content %}
-<div class="space-y-8 py-5">
-  <section class="grid gap-5 sm:grid-cols-2 xl:grid-cols-4">
-    <article class="flex flex-col gap-3 rounded-3xl border border-sky-300 bg-sky-200 p-5 shadow-sm">
-      <div class="flex items-center justify-between">
-        <span class="text-lg font-semibold text-sky-900">Abiertos</span>
-        <span class="flex h-11 w-11 items-center justify-center rounded-full bg-white text-xl text-sky-600 shadow-sm"><i class="bi bi-life-preserver"></i></span>
-      </div>
-      <p class="text-5xl font-semibold text-slate-900">{{ counts.open }}</p>
-    </article>
-
-    <article class="flex flex-col gap-3 rounded-3xl border border-amber-300 bg-amber-200 p-5 shadow-sm">
-      <div class="flex items-center justify-between">
-        <span class="text-lg font-semibold text-amber-900">En progreso</span>
-        <span class="flex h-11 w-11 items-center justify-center rounded-full bg-white text-xl text-amber-600 shadow-sm"><i class="bi bi-gear-wide-connected"></i></span>
-      </div>
-      <p class="text-5xl font-semibold text-slate-900">{{ counts.in_progress }}</p>
-    </article>
-
-    <article class="flex flex-col gap-3 rounded-3xl border border-emerald-300 bg-emerald-200 p-5 shadow-sm">
-      <div class="flex items-center justify-between">
-        <span class="text-lg font-semibold text-emerald-900">Resueltos (mes)</span>
-        <span class="flex h-11 w-11 items-center justify-center rounded-full bg-white text-xl text-emerald-600 shadow-sm"><i class="bi bi-check-circle"></i></span>
-      </div>
-      <p class="text-5xl font-semibold text-slate-900">{{ counts.resolved }}</p>
-    </article>
-
-    <article class="flex flex-col gap-3 rounded-3xl border border-rose-300 bg-rose-200 p-5 shadow-sm">
-      <div class="flex items-center justify-between">
-        <span class="text-lg font-semibold text-rose-900">Cerrados (mes)</span>
-        <span class="flex h-11 w-11 items-center justify-center rounded-full bg-white text-xl text-rose-600 shadow-sm"><i class="bi bi-shield-lock"></i></span>
-      </div>
-      <p class="text-5xl font-semibold text-slate-900">{{ counts.closed }}</p>
-    </article>
-  </section>
-
-  <section class="grid gap-5 lg:grid-cols-[1.05fr_1fr]">
-    <article class="rounded-3xl border border-rose-100 bg-white p-6 shadow-sm">
-      <div class="flex flex-col gap-3">
-        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 class="text-2xl font-semibold text-slate-900">Tickets urgentes</h2>
-            <p class="text-sm text-slate-600">Atiende incidentes críticos con un vistazo al tiempo restante y responsables.</p>
-          </div>
-          <span class="inline-flex items-center gap-2 rounded-full bg-rose-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-rose-500"><i class="bi bi-lightning-charge"></i> Prioridad</span>
-        </div>
-        {% if urgent_tickets %}
-        <ul class="space-y-3" role="list">
-          {% for ticket in urgent_tickets %}
-          <li class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-slate-300">
-            <div class="flex flex-wrap items-center justify-between gap-3 text-sm">
-              <a href="{% url 'ticket_detail' ticket.id %}" class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 font-semibold text-slate-700 transition hover:bg-slate-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400" aria-label="Abrir ticket {{ ticket.code }}">
-                <i class="bi bi-hash"></i>
-                {{ ticket.code }}
-              </a>
-              <span class="inline-flex items-center gap-2 rounded-full bg-rose-100 px-3 py-1 text-xs font-semibold text-rose-600"><i class="bi bi-exclamation-triangle-fill"></i> {{ ticket.priority.name }}</span>
-            </div>
-            <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <p class="text-base font-semibold text-slate-900">{{ ticket.title }}</p>
-              <div class="flex items-center gap-3 text-sm text-slate-600">
-                <span class="inline-flex items-center gap-2 rounded-full bg-white px-3 py-1"><i class="bi bi-person-circle"></i>{% if ticket.assigned_to %}{{ ticket.assigned_to.username }}{% else %}-{% endif %}</span>
-                <span class="inline-flex items-center gap-2 rounded-full bg-amber-100 px-3 py-1 text-amber-700 font-semibold"><i class="bi bi-hourglass-split"></i> {{ ticket.remaining_hours|floatformat:1 }} h</span>
-              </div>
-            </div>
-          </li>
-          {% endfor %}
-        </ul>
-        {% else %}
-        <div class="flex flex-col items-center justify-center gap-3 rounded-2xl border border-emerald-100 bg-emerald-50/70 p-8 text-center text-sm text-emerald-600">
-          <i class="bi bi-emoji-smile text-3xl"></i>
-          <p class="max-w-md text-base">No hay tickets urgentes en este momento. Tu equipo mantiene el control absoluto.</p>
-        </div>
-        {% endif %}
-      </div>
-    </article>
-
-    <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-      <div class="flex flex-col gap-3">
-        <div>
-          <h2 class="text-2xl font-semibold text-slate-900">Distribución actual</h2>
-          <p class="text-sm text-slate-600">Una visión clara del estado de los tickets al momento.</p>
-        </div>
-        <div class="mx-auto mt-3 h-80 w-full max-w-2xl">
-          <canvas id="statusChart" aria-label="Gráfico circular de estado de tickets"></canvas>
-        </div>
-        <div id="statusFilters" class="mt-5 flex flex-wrap gap-3">
-          <label class="status-chip flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-sky-200 hover:bg-sky-50" data-index="0">
-            <input type="checkbox" class="status-toggle sr-only" data-index="0" checked>
-            <span class="flex items-center gap-2">
-              <span class="inline-flex h-2.5 w-2.5 rounded-full" style="background-color: #bae6fd"></span>
-              Abiertos
-            </span>
-            <span class="ml-2 text-xs font-semibold text-slate-400">{{ counts.open }}</span>
-          </label>
-          <label class="status-chip flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-sky-200 hover:bg-sky-50" data-index="1">
-            <input type="checkbox" class="status-toggle sr-only" data-index="1" checked>
-            <span class="flex items-center gap-2">
-              <span class="inline-flex h-2.5 w-2.5 rounded-full" style="background-color: #fde68a"></span>
-              En progreso
-            </span>
-            <span class="ml-2 text-xs font-semibold text-slate-400">{{ counts.in_progress }}</span>
-          </label>
-          <label class="status-chip flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-sky-200 hover:bg-sky-50" data-index="2">
-            <input type="checkbox" class="status-toggle sr-only" data-index="2" checked>
-            <span class="flex items-center gap-2">
-              <span class="inline-flex h-2.5 w-2.5 rounded-full" style="background-color: #a7f3d0"></span>
-              Resueltos (mes)
-            </span>
-            <span class="ml-2 text-xs font-semibold text-slate-400">{{ counts.resolved }}</span>
-          </label>
-          <label class="status-chip flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-sky-200 hover:bg-sky-50" data-index="3">
-            <input type="checkbox" class="status-toggle sr-only" data-index="3" checked>
-            <span class="flex items-center gap-2">
-              <span class="inline-flex h-2.5 w-2.5 rounded-full" style="background-color: #fecdd3"></span>
-              Cerrados (mes)
-            </span>
-            <span class="ml-2 text-xs font-semibold text-slate-400">{{ counts.closed }}</span>
-          </label>
-        </div>
-        <p class="text-xs text-slate-500">Desmarca los estados que prefieras ocultar del gráfico circular.</p>
-      </div>
-    </article>
-  </section>
-
-  <section id="tendencias" class="grid gap-5 xl:grid-cols-[2fr_1fr]">
-    <article class="rounded-3xl border border-sky-100 bg-white p-6 shadow-sm">
-      <div class="flex flex-col gap-3">
-        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <div>
-            <h2 class="text-2xl font-semibold text-slate-900">Tendencias de fallas</h2>
-            <p class="text-sm text-slate-600">Detecta patrones, dimensiona impacto y acciona planes preventivos.</p>
-          </div>
-          {% if has_failures_data %}
-          <span class="inline-flex items-center gap-2 rounded-full bg-sky-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-sky-600"><i class="bi bi-clock-history"></i> Datos desde {{ failures_since|localtime|date:"d/m/Y" }}</span>
-          {% endif %}
-        </div>
-
-        {% if has_failures_data %}
-        <div class="relative rounded-[1.75rem] border border-sky-100 bg-gradient-to-br from-sky-50 via-white to-emerald-50 p-5 shadow-inner">
-          <div class="relative h-72">
-            <canvas id="failuresChart" aria-label="Gráfico de barras con tendencias de fallas"></canvas>
-          </div>
-        </div>
-        {% else %}
-        <div class="flex flex-col items-center justify-center gap-3 rounded-2xl border border-sky-100 bg-sky-50/70 p-8 text-center text-sm text-sky-600">
-          <i class="bi bi-info-circle text-3xl"></i>
-          <p class="max-w-md text-base">No hay registros recientes suficientes para mostrar tendencias de fallas. Mantén la monitorización para descubrir patrones emergentes.</p>
-        </div>
-        {% endif %}
-      </div>
-    </article>
-
-    <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
-      <div class="flex h-full flex-col gap-3">
-        <div>
-          <h3 class="text-lg font-semibold text-slate-900">Fallas más comunes</h3>
-          <p class="text-sm text-slate-600">Top 15 categorías con mayor volumen reportado.</p>
-        </div>
-        {% if failure_breakdown %}
-        <ul class="space-y-3 overflow-y-auto pr-2" role="list">
-          {% for failure in failure_breakdown %}
-          <li class="space-y-2 rounded-2xl border border-slate-200 bg-slate-50 p-3.5 shadow-sm">
+<div class="relative">
+  <div id="dashboardShell" class="dashboard-shell dashboard-shell--compact">
+    <div class="dashboard-shell__scrim" aria-hidden="true"></div>
+    <div class="dashboard-shell__content">
+      <div class="space-y-8 py-5">
+        <section class="grid gap-5 sm:grid-cols-2 xl:grid-cols-4">
+          <article class="flex flex-col gap-3 rounded-3xl border border-sky-300 bg-sky-200 p-5 shadow-sm">
             <div class="flex items-center justify-between">
-              <div class="flex items-center gap-3">
-                <span class="flex h-10 w-10 items-center justify-center rounded-full font-semibold text-slate-700" style="background: linear-gradient(135deg, {{ failure.color }}33, {{ failure.color }}55);">{{ forloop.counter }}</span>
-                <span class="text-sm font-semibold text-slate-900">{{ failure.label }}</span>
-              </div>
-              <span class="text-sm font-semibold text-slate-600">{{ failure.total }}</span>
+              <span class="text-lg font-semibold text-sky-900">Abiertos</span>
+              <span class="flex h-11 w-11 items-center justify-center rounded-full bg-white text-xl text-sky-600 shadow-sm"><i class="bi bi-life-preserver"></i></span>
             </div>
-            <div class="h-2 w-full overflow-hidden rounded-full bg-white">
-              {% if failure_breakdown.0.total %}
-              <div class="h-full rounded-full" style="background: linear-gradient(90deg, {{ failure.color }}66, {{ failure.color }}aa); width: {% widthratio failure.total failure_breakdown.0.total 100 %}%;"></div>
+            <p class="text-5xl font-semibold text-slate-900">{{ counts.open }}</p>
+          </article>
+
+          <article class="flex flex-col gap-3 rounded-3xl border border-amber-300 bg-amber-200 p-5 shadow-sm">
+            <div class="flex items-center justify-between">
+              <span class="text-lg font-semibold text-amber-900">En progreso</span>
+              <span class="flex h-11 w-11 items-center justify-center rounded-full bg-white text-xl text-amber-600 shadow-sm"><i class="bi bi-gear-wide-connected"></i></span>
+            </div>
+            <p class="text-5xl font-semibold text-slate-900">{{ counts.in_progress }}</p>
+          </article>
+
+          <article class="flex flex-col gap-3 rounded-3xl border border-emerald-300 bg-emerald-200 p-5 shadow-sm">
+            <div class="flex items-center justify-between">
+              <span class="text-lg font-semibold text-emerald-900">Resueltos (mes)</span>
+              <span class="flex h-11 w-11 items-center justify-center rounded-full bg-white text-xl text-emerald-600 shadow-sm"><i class="bi bi-check-circle"></i></span>
+            </div>
+            <p class="text-5xl font-semibold text-slate-900">{{ counts.resolved }}</p>
+          </article>
+
+          <article class="flex flex-col gap-3 rounded-3xl border border-rose-300 bg-rose-200 p-5 shadow-sm">
+            <div class="flex items-center justify-between">
+              <span class="text-lg font-semibold text-rose-900">Cerrados (mes)</span>
+              <span class="flex h-11 w-11 items-center justify-center rounded-full bg-white text-xl text-rose-600 shadow-sm"><i class="bi bi-shield-lock"></i></span>
+            </div>
+            <p class="text-5xl font-semibold text-slate-900">{{ counts.closed }}</p>
+          </article>
+        </section>
+
+        <section class="grid gap-5 lg:grid-cols-[1.05fr_1fr]">
+          <article class="rounded-3xl border border-rose-100 bg-white p-6 shadow-sm">
+            <div class="flex flex-col gap-3">
+              <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h2 class="text-2xl font-semibold text-slate-900">Tickets urgentes</h2>
+                  <p class="text-sm text-slate-600">Atiende incidentes críticos con un vistazo al tiempo restante y responsables.</p>
+                </div>
+                <span class="inline-flex items-center gap-2 rounded-full bg-rose-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-rose-500"><i class="bi bi-lightning-charge"></i> Prioridad</span>
+              </div>
+              {% if urgent_tickets %}
+              <ul class="space-y-3" role="list">
+                {% for ticket in urgent_tickets %}
+                <li class="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm transition hover:border-slate-300">
+                  <div class="flex flex-wrap items-center justify-between gap-3 text-sm">
+                    <a href="{% url 'ticket_detail' ticket.id %}" class="inline-flex items-center gap-2 rounded-full bg-slate-100 px-3 py-1 font-semibold text-slate-700 transition hover:bg-slate-200 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-slate-400" aria-label="Abrir ticket {{ ticket.code }}">
+                      <i class="bi bi-hash"></i>
+                      {{ ticket.code }}
+                    </a>
+                    <span class="inline-flex items-center gap-2 rounded-full bg-rose-100 px-3 py-1 text-xs font-semibold text-rose-600"><i class="bi bi-exclamation-triangle-fill"></i> {{ ticket.priority.name }}</span>
+                  </div>
+                  <div class="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                    <p class="text-base font-semibold text-slate-900">{{ ticket.title }}</p>
+                    <div class="flex items-center gap-3 text-sm text-slate-600">
+                      <span class="inline-flex items-center gap-2 rounded-full bg-white px-3 py-1"><i class="bi bi-person-circle"></i>{% if ticket.assigned_to %}{{ ticket.assigned_to.username }}{% else %}-{% endif %}</span>
+                      <span class="inline-flex items-center gap-2 rounded-full bg-amber-100 px-3 py-1 text-amber-700 font-semibold"><i class="bi bi-hourglass-split"></i> {{ ticket.remaining_hours|floatformat:1 }} h</span>
+                    </div>
+                  </div>
+                </li>
+                {% endfor %}
+              </ul>
               {% else %}
-              <div class="h-full rounded-full" style="background: linear-gradient(90deg, {{ failure.color }}66, {{ failure.color }}aa); width: 0;"></div>
+              <div class="flex flex-col items-center justify-center gap-3 rounded-2xl border border-emerald-100 bg-emerald-50/70 p-8 text-center text-sm text-emerald-600">
+                <i class="bi bi-emoji-smile text-3xl"></i>
+                <p class="max-w-md text-base">No hay tickets urgentes en este momento. Tu equipo mantiene el control absoluto.</p>
+              </div>
               {% endif %}
             </div>
-          </li>
-          {% endfor %}
-        </ul>
-        {% else %}
-        <div class="flex flex-col items-center justify-center gap-3 rounded-2xl border border-slate-200 bg-slate-50/80 p-8 text-center text-sm text-slate-600">
-          <i class="bi bi-clipboard2-check text-3xl text-slate-500"></i>
-          <p class="max-w-xs text-base">Aún no hay suficiente información para crear un ranking de fallas frecuentes.</p>
-        </div>
-        {% endif %}
+          </article>
+
+          <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <div class="flex flex-col gap-3">
+              <div>
+                <h2 class="text-2xl font-semibold text-slate-900">Distribución actual</h2>
+                <p class="text-sm text-slate-600">Una visión clara del estado de los tickets al momento.</p>
+              </div>
+              <div class="mx-auto mt-3 h-80 w-full max-w-2xl">
+                <canvas id="statusChart" aria-label="Gráfico circular de estado de tickets"></canvas>
+              </div>
+              <div id="statusFilters" class="mt-5 flex flex-wrap gap-3">
+                <label class="status-chip flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-sky-200 hover:bg-sky-50" data-index="0">
+                  <input type="checkbox" class="status-toggle sr-only" data-index="0" checked>
+                  <span class="flex items-center gap-2">
+                    <span class="inline-flex h-2.5 w-2.5 rounded-full" style="background-color: #bae6fd"></span>
+                    Abiertos
+                  </span>
+                  <span class="ml-2 text-xs font-semibold text-slate-400">{{ counts.open }}</span>
+                </label>
+                <label class="status-chip flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-sky-200 hover:bg-sky-50" data-index="1">
+                  <input type="checkbox" class="status-toggle sr-only" data-index="1" checked>
+                  <span class="flex items-center gap-2">
+                    <span class="inline-flex h-2.5 w-2.5 rounded-full" style="background-color: #fde68a"></span>
+                    En progreso
+                  </span>
+                  <span class="ml-2 text-xs font-semibold text-slate-400">{{ counts.in_progress }}</span>
+                </label>
+                <label class="status-chip flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-sky-200 hover:bg-sky-50" data-index="2">
+                  <input type="checkbox" class="status-toggle sr-only" data-index="2" checked>
+                  <span class="flex items-center gap-2">
+                    <span class="inline-flex h-2.5 w-2.5 rounded-full" style="background-color: #a7f3d0"></span>
+                    Resueltos (mes)
+                  </span>
+                  <span class="ml-2 text-xs font-semibold text-slate-400">{{ counts.resolved }}</span>
+                </label>
+                <label class="status-chip flex items-center gap-2 rounded-full border border-slate-200 bg-slate-50 px-4 py-2 text-sm font-medium text-slate-600 shadow-sm transition hover:border-sky-200 hover:bg-sky-50" data-index="3">
+                  <input type="checkbox" class="status-toggle sr-only" data-index="3" checked>
+                  <span class="flex items-center gap-2">
+                    <span class="inline-flex h-2.5 w-2.5 rounded-full" style="background-color: #fecdd3"></span>
+                    Cerrados (mes)
+                  </span>
+                  <span class="ml-2 text-xs font-semibold text-slate-400">{{ counts.closed }}</span>
+                </label>
+              </div>
+              <p class="text-xs text-slate-500">Desmarca los estados que prefieras ocultar del gráfico circular.</p>
+            </div>
+          </article>
+        </section>
+
+        <section id="tendencias" class="grid gap-5 xl:grid-cols-[2fr_1fr]">
+          <article class="rounded-3xl border border-sky-100 bg-white p-6 shadow-sm">
+            <div class="flex flex-col gap-3">
+              <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+                <div>
+                  <h2 class="text-2xl font-semibold text-slate-900">Tendencias de fallas</h2>
+                  <p class="text-sm text-slate-600">Detecta patrones, dimensiona impacto y acciona planes preventivos.</p>
+                </div>
+                {% if has_failures_data %}
+                <span class="inline-flex items-center gap-2 rounded-full bg-sky-50 px-3 py-1 text-xs font-semibold uppercase tracking-[0.25em] text-sky-600"><i class="bi bi-clock-history"></i> Datos desde {{ failures_since|localtime|date:"d/m/Y" }}</span>
+                {% endif %}
+              </div>
+
+              {% if has_failures_data %}
+              <div class="relative rounded-[1.75rem] border border-sky-100 bg-gradient-to-br from-sky-50 via-white to-emerald-50 p-5 shadow-inner">
+                <div class="relative h-72">
+                  <canvas id="failuresChart" aria-label="Gráfico de barras con tendencias de fallas"></canvas>
+                </div>
+              </div>
+              {% else %}
+              <div class="flex flex-col items-center justify-center gap-3 rounded-2xl border border-sky-100 bg-sky-50/70 p-8 text-center text-sm text-sky-600">
+                <i class="bi bi-info-circle text-3xl"></i>
+                <p class="max-w-md text-base">No hay registros recientes suficientes para mostrar tendencias de fallas. Mantén la monitorización para descubrir patrones emergentes.</p>
+              </div>
+              {% endif %}
+            </div>
+          </article>
+
+          <article class="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <div class="flex h-full flex-col gap-3">
+              <div>
+                <h3 class="text-lg font-semibold text-slate-900">Fallas más comunes</h3>
+                <p class="text-sm text-slate-600">Top 15 categorías con mayor volumen reportado.</p>
+              </div>
+              {% if failure_breakdown %}
+              <ul class="space-y-3 overflow-y-auto pr-2" role="list">
+                {% for failure in failure_breakdown %}
+                <li class="space-y-2 rounded-2xl border border-slate-200 bg-slate-50 p-3.5 shadow-sm">
+                  <div class="flex items-center justify-between">
+                    <div class="flex items-center gap-3">
+                      <span class="flex h-10 w-10 items-center justify-center rounded-full font-semibold text-slate-700" style="background: linear-gradient(135deg, {{ failure.color }}33, {{ failure.color }}55);">{{ forloop.counter }}</span>
+                      <span class="text-sm font-semibold text-slate-900">{{ failure.label }}</span>
+                    </div>
+                    <span class="text-sm font-semibold text-slate-600">{{ failure.total }}</span>
+                  </div>
+                  <div class="h-2 w-full overflow-hidden rounded-full bg-white">
+                    {% if failure_breakdown.0.total %}
+                    <div class="h-full rounded-full" style="background: linear-gradient(90deg, {{ failure.color }}66, {{ failure.color }}aa); width: {% widthratio failure.total failure_breakdown.0.total 100 %}%;"></div>
+                    {% else %}
+                    <div class="h-full rounded-full" style="background: linear-gradient(90deg, {{ failure.color }}66, {{ failure.color }}aa); width: 0;"></div>
+                    {% endif %}
+                  </div>
+                </li>
+                {% endfor %}
+              </ul>
+              {% else %}
+              <div class="flex flex-col items-center justify-center gap-3 rounded-2xl border border-slate-200 bg-slate-50/80 p-8 text-center text-sm text-slate-600">
+                <i class="bi bi-clipboard2-check text-3xl text-slate-500"></i>
+                <p class="max-w-xs text-base">Aún no hay suficiente información para crear un ranking de fallas frecuentes.</p>
+              </div>
+              {% endif %}
+            </div>
+          </article>
+        </section>
       </div>
-    </article>
-  </section>
+    </div>
+  </div>
+  <button type="button" id="dashboardToggle" class="dashboard-toggle" aria-controls="dashboardShell" aria-expanded="false">
+    <i class="dashboard-toggle__icon bi bi-arrows-fullscreen" data-icon="expand"></i>
+    <i class="dashboard-toggle__icon bi bi-fullscreen-exit hidden" data-icon="collapse"></i>
+    <span data-label>Ampliar tablero</span>
+  </button>
 </div>
 {% endblock %}
 
@@ -197,6 +304,63 @@
 <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 <script>
   document.addEventListener('DOMContentLoaded', () => {
+    const dashboardShell = document.getElementById('dashboardShell');
+    const dashboardToggle = document.getElementById('dashboardToggle');
+
+    if (dashboardShell && dashboardToggle) {
+      const expandIcon = dashboardToggle.querySelector('[data-icon="expand"]');
+      const collapseIcon = dashboardToggle.querySelector('[data-icon="collapse"]');
+      const label = dashboardToggle.querySelector('[data-label]');
+      const mediaQuery = window.matchMedia('(min-width: 1025px)');
+      let expanded = sessionStorage.getItem('dashboardExpanded') === '1';
+
+      const applyState = (isExpanded) => {
+        dashboardShell.classList.toggle('dashboard-shell--expanded', isExpanded);
+        dashboardShell.classList.toggle('dashboard-shell--compact', !isExpanded);
+        dashboardToggle.setAttribute('aria-expanded', isExpanded ? 'true' : 'false');
+
+        if (expandIcon && collapseIcon) {
+          expandIcon.classList.toggle('hidden', isExpanded);
+          collapseIcon.classList.toggle('hidden', !isExpanded);
+        }
+
+        if (label) {
+          label.textContent = isExpanded ? 'Reducir tablero' : 'Ampliar tablero';
+        }
+      };
+
+      const syncState = () => {
+        if (!mediaQuery.matches) {
+          dashboardShell.classList.remove('dashboard-shell--compact', 'dashboard-shell--expanded');
+          dashboardToggle.setAttribute('aria-hidden', 'true');
+          dashboardToggle.setAttribute('tabindex', '-1');
+          return;
+        }
+
+        dashboardToggle.removeAttribute('aria-hidden');
+        dashboardToggle.removeAttribute('tabindex');
+        applyState(expanded);
+      };
+
+      syncState();
+      mediaQuery.addEventListener('change', syncState);
+
+      dashboardToggle.addEventListener('click', () => {
+        if (!mediaQuery.matches) {
+          return;
+        }
+
+        expanded = !expanded;
+        applyState(expanded);
+
+        if (expanded) {
+          sessionStorage.setItem('dashboardExpanded', '1');
+        } else {
+          sessionStorage.removeItem('dashboardExpanded');
+        }
+      });
+    }
+
     const statusConfig = {{ chart_data|safe }};
     const failuresConfig = {{ failures_chart_data|safe }};
     const hasFailureData = {{ has_failures_data|yesno:"true,false" }};


### PR DESCRIPTION
## Summary
- reduce the hero blocks padding and typography so they occupy less vertical space across the app
- wrap the dashboard sections in a compact shell with a corner toggle to expand to a full-size view when needed
- add responsive styling and JavaScript to persist the chosen dashboard size and keep charts working

## Testing
- python manage.py runserver 0.0.0.0:8000 *(fails: Django not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e5aa1c7b9883219a021f1b960b7d2b